### PR TITLE
Identifying pipeline build also based on dependents

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogNotificator.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogNotificator.java
@@ -82,7 +82,7 @@ public class DatadogNotificator extends NotificatorAdapter {
     @VisibleForTesting
     protected void onFinishedBuild(DatadogBuild build) {
         //TODO for now we are only generating payloads for pipelines (job support in CIAPP-5340)
-        if (isPipelineBuild(build)) {
+        if (build.isPipelineBuild()) {
             Optional<String> optionalProjectID = Optional.ofNullable(build.projectID());
             ProjectParameters params = projectHandler.getProjectParameters(optionalProjectID);
 
@@ -91,12 +91,6 @@ public class DatadogNotificator extends NotificatorAdapter {
         } else {
             LOG.info("Job webhooks not supported yet");
         }
-    }
-
-
-    //TODO For now this method just checks for composite builds, it will be really implemented with CIAPP-5339.
-    private boolean isPipelineBuild(DatadogBuild datadogBuild) {
-        return datadogBuild.isComposite();
     }
 
     private Pipeline createPipeline(DatadogBuild datadogBuild) {

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/model/DatadogBuild.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/model/DatadogBuild.java
@@ -18,9 +18,17 @@ public class DatadogBuild {
     private final String projectID;
     private final Date startDate;
     private final Date finishDate;
+    private final int dependentOnMe;
 
     @VisibleForTesting
-    public DatadogBuild(long id, String name, Status status, boolean isComposite, String projectID, Date startDate, Date finishDate) {
+    public DatadogBuild(long id,
+                        String name,
+                        Status status,
+                        boolean isComposite,
+                        String projectID,
+                        Date startDate,
+                        Date finishDate,
+                        int dependentOnMe) {
         this.id = id;
         this.name = name;
         this.status = status;
@@ -28,11 +36,13 @@ public class DatadogBuild {
         this.projectID = projectID;
         this.startDate = startDate;
         this.finishDate = finishDate;
+        this.dependentOnMe = dependentOnMe;
     }
 
     public static DatadogBuild fromBuild(SBuild build) {
+        int dependentOnMe = build.getBuildPromotion().getDependedOnMe().size();
         return new DatadogBuild(build.getBuildId(), build.getFullName(), build.getBuildStatus(),
-                build.isCompositeBuild(), build.getProjectId(), build.getStartDate(), build.getFinishDate());
+                build.isCompositeBuild(), build.getProjectId(), build.getStartDate(), build.getFinishDate(), dependentOnMe);
     }
 
     public long id() {
@@ -47,10 +57,6 @@ public class DatadogBuild {
         return status;
     }
 
-    public boolean isComposite() {
-        return isComposite;
-    }
-
     public String projectID() {
         return projectID;
     }
@@ -61,5 +67,9 @@ public class DatadogBuild {
 
     public Date finishDate() {
         return finishDate;
+    }
+
+    public boolean isPipelineBuild() {
+        return isComposite && dependentOnMe == 0;
     }
 }


### PR DESCRIPTION
The pipeline webhook should be emitted when we encounter a build which is:
- A composite build
- The last on the chain