### PR TITLE
[CIAPP-5361] Adding retries when sending webhooks

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.com.datadog.teamcity.plugin.model.entities.CIEntity;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 
@@ -20,26 +23,55 @@ public class DatadogClient {
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
+    private final RetryInformation retryInfo;
 
-    public DatadogClient(RestTemplate restTemplate, ObjectMapper objectMapper) {
+    public DatadogClient(RestTemplate restTemplate, ObjectMapper objectMapper, RetryInformation retryInfo) {
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
+        this.retryInfo = retryInfo;
     }
 
-    public void sendWebhook(CIEntity entity, String apiKey, String ddSite) {
+    public boolean sendWebhook(CIEntity entity, String apiKey, String ddSite) {
         String url = format("https://webhook-intake.%s/api/v2/webhook", ddSite);
         HttpHeaders headers = getHeaders(apiKey);
         String payload = serialize(entity);
 
-        // TODO this will be enhanced to retry on transient failures (CIAPP-5361)
+        return sendWebhookWithRetries(url, payload, headers);
+    }
+
+    private boolean sendWebhookWithRetries(String url, String payload, HttpHeaders headers) {
         HttpEntity<String> request = new HttpEntity<>(payload, headers);
-        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, request, String.class);
-        if (response.getStatusCode().is2xxSuccessful()) {
-            LOG.info(format("Successfully sent webhook to url '%s' with body '%s' and headers '%s'", url, payload, headers));
-        } else {
-            LOG.info(format("Could not send webhook to url '%s' with body '%s' and headers '%s'. Status code: '%s'",
-                    url, payload, headers, response.getStatusCode()));
+        int currentAttempt = 0;
+
+        // TODO remove content and headers from logs before publishing
+        while (currentAttempt <= retryInfo.maxRetries) {
+            try {
+                ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, request, String.class);
+                if (response.getStatusCode().is2xxSuccessful()) {
+                    LOG.info(format("Successfully sent webhook to url '%s' with body '%s' and headers '%s'", url, payload, headers));
+                    return true;
+                } else if (response.getStatusCode().is5xxServerError()) {
+                    LOG.warn(format("Could not send webhook to url '%s' with body '%s' and headers '%s'. " +
+                                    "Status code: '%s', Retry number %d/%d",
+                            url, payload, headers, response.getStatusCode(), currentAttempt, retryInfo.maxRetries));
+
+                    sleepSeconds(retryInfo.backoffSeconds);
+                } else {
+                    // Status code is different from 5xx, so we won't retry
+                    LOG.warn(format("Could not send webhook to url '%s' with body '%s' and headers '%s'. " +
+                                    "Status code: '%s'.", url, payload, headers, response.getStatusCode()));
+                    return false;
+                }
+            } catch (RestClientException ex) {
+                LOG.error(format("Exception occurred while sending webhooks to to url '%s' with body '%s' and headers '%s'" +
+                                ". Retry number %d/%d: ", url, payload, headers, currentAttempt, retryInfo.maxRetries), ex);
+                sleepSeconds(retryInfo.backoffSeconds);
+            }
+
+            currentAttempt++;
         }
+
+        return false;
     }
 
     private HttpHeaders getHeaders(String apiKey) {
@@ -55,6 +87,25 @@ public class DatadogClient {
             return objectMapper.writeValueAsString(entity);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(format("Could not serialize the content of the entity: %s", entity), e);
+        }
+    }
+
+    private void sleepSeconds(int seconds) {
+        try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(seconds));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class RetryInformation {
+        private final int maxRetries;
+        private final int backoffSeconds;
+
+        public RetryInformation(int maxRetries, int backoffSeconds) {
+            this.maxRetries = maxRetries;
+            this.backoffSeconds = backoffSeconds;
         }
     }
 }

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogConfiguration.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogConfiguration.java
@@ -2,6 +2,7 @@ package jetbrains.buildServer.com.datadog.teamcity.plugin;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jetbrains.buildServer.com.datadog.teamcity.plugin.DatadogClient.RetryInformation;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -9,9 +10,12 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class DatadogConfiguration {
 
+    private static final int MAX_RETRIES = 3;
+    private static final int BACKOFF_SECONDS = 10;
+
     @Bean
     public DatadogClient datadogClient(ObjectMapper objectMapper) {
-        return new DatadogClient(new RestTemplate(), objectMapper);
+        return new DatadogClient(new RestTemplate(), objectMapper, new RetryInformation(MAX_RETRIES, BACKOFF_SECONDS));
     }
 
     @Bean

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClientTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClientTest.java
@@ -2,6 +2,7 @@ package jetbrains.buildServer.com.datadog.teamcity.plugin;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jetbrains.buildServer.com.datadog.teamcity.plugin.DatadogClient.RetryInformation;
 import jetbrains.buildServer.com.datadog.teamcity.plugin.model.entities.Pipeline;
 import org.junit.Before;
 import org.junit.Test;
@@ -9,6 +10,7 @@ import org.mockito.*;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import static jetbrains.buildServer.com.datadog.teamcity.plugin.DatadogClient.DD_API_KEY_HEADER;
@@ -18,8 +20,12 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 public class DatadogClientTest {
+
+    private static final int MAX_RETRIES_TEST = 2;
+    private static final int BACKOFF_SECONDS_TEST = 0;
 
     @Captor
     private ArgumentCaptor<HttpEntity<String>> requestCaptor;
@@ -31,7 +37,9 @@ public class DatadogClientTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         restTemplateMock = Mockito.mock(RestTemplate.class);
-        datadogClient = new DatadogClient(restTemplateMock, new ObjectMapper());
+
+        RetryInformation retryInfo = new RetryInformation(MAX_RETRIES_TEST, BACKOFF_SECONDS_TEST);
+        datadogClient = new DatadogClient(restTemplateMock, new ObjectMapper(), retryInfo);
     }
 
     @Test
@@ -43,11 +51,12 @@ public class DatadogClientTest {
 
         // When
         Pipeline pipeline = testPipeline();
-        datadogClient.sendWebhook(pipeline, mockApiKey, "datad0g.com");
+        boolean successful = datadogClient.sendWebhook(pipeline, mockApiKey, "datad0g.com");
 
         // Then
         Mockito.verify(restTemplateMock, times(1))
                 .exchange(eq("https://webhook-intake.datad0g.com/api/v2/webhook"), eq(POST), requestCaptor.capture(), eq(String.class));
+        assertThat(successful).isTrue();
 
         HttpEntity<String> requestDone = requestCaptor.getValue();
         assertThat(requestDone.getHeaders().toSingleValueMap())
@@ -57,6 +66,76 @@ public class DatadogClientTest {
                 .containsEntry(DD_CI_PROVIDER_HEADER, "teamcity");
 
         assertThat(requestDone.getBody()).isEqualTo(new ObjectMapper().writeValueAsString(pipeline));
+    }
+
+    @Test
+    public void shouldRetryOnServerErrors() {
+        // Setup
+        String mockApiKey = "mock-api-key";
+        when(restTemplateMock.exchange(anyString(), eq(POST), any(), Matchers.<Class<String>>any()))
+                .thenReturn(ResponseEntity.status(INTERNAL_SERVER_ERROR).body("Server error"))
+                .thenReturn(ResponseEntity.ok("Successful Request"));
+
+        // When
+        Pipeline pipeline = testPipeline();
+        boolean successful = datadogClient.sendWebhook(pipeline, mockApiKey, "datad0g.com");
+
+        // Then
+        Mockito.verify(restTemplateMock, times(2))
+                .exchange(eq("https://webhook-intake.datad0g.com/api/v2/webhook"), eq(POST), requestCaptor.capture(), eq(String.class));
+        assertThat(successful).isTrue();
+    }
+
+    @Test
+    public void shouldRetryOnTransientExceptions() {
+        // Setup
+        String mockApiKey = "mock-api-key";
+        when(restTemplateMock.exchange(anyString(), eq(POST), any(), Matchers.<Class<String>>any()))
+                .thenThrow(new RestClientException("Transient exception"))
+                .thenReturn(ResponseEntity.ok("Successful Request"));
+
+        // When
+        Pipeline pipeline = testPipeline();
+        boolean successful = datadogClient.sendWebhook(pipeline, mockApiKey, "datad0g.com");
+
+        // Then
+        Mockito.verify(restTemplateMock, times(2))
+                .exchange(eq("https://webhook-intake.datad0g.com/api/v2/webhook"), eq(POST), requestCaptor.capture(), eq(String.class));
+        assertThat(successful).isTrue();
+    }
+
+    @Test
+    public void shouldNotRetryOnClientError() {
+        // Setup
+        String mockApiKey = "mock-api-key";
+        when(restTemplateMock.exchange(anyString(), eq(POST), any(), Matchers.<Class<String>>any()))
+                .thenReturn(ResponseEntity.badRequest().body("Bad request"));
+
+        // When
+        Pipeline pipeline = testPipeline();
+        boolean successful = datadogClient.sendWebhook(pipeline, mockApiKey, "datad0g.com");
+
+        // Then
+        Mockito.verify(restTemplateMock, times(1))
+                .exchange(eq("https://webhook-intake.datad0g.com/api/v2/webhook"), eq(POST), requestCaptor.capture(), eq(String.class));
+        assertThat(successful).isFalse();
+    }
+
+    @Test
+    public void shouldStopRetrying() {
+        // Setup
+        String mockApiKey = "mock-api-key";
+        when(restTemplateMock.exchange(anyString(), eq(POST), any(), Matchers.<Class<String>>any()))
+                .thenReturn(ResponseEntity.status(INTERNAL_SERVER_ERROR).body("Server error"));
+
+        // When
+        Pipeline pipeline = testPipeline();
+        boolean successful = datadogClient.sendWebhook(pipeline, mockApiKey, "datad0g.com");
+
+        // Then
+        Mockito.verify(restTemplateMock, times(3)) // 1 normal and 2 retries
+                .exchange(eq("https://webhook-intake.datad0g.com/api/v2/webhook"), eq(POST), requestCaptor.capture(), eq(String.class));
+        assertThat(successful).isFalse();
     }
 
     private static Pipeline testPipeline() {


### PR DESCRIPTION
Adding retries when sending webhooks to public intake to be resilient to transient failures.