### PR TITLE
[CIAPP-5375] Builds triggered by user are not marked as partial retries

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildUtils.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildUtils.java
@@ -2,7 +2,6 @@ package jetbrains.buildServer.com.datadog.teamcity.plugin;
 
 import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.SBuild;
-import jetbrains.buildServer.serverSide.TriggeredBy;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -29,9 +28,7 @@ public final class BuildUtils {
     }
 
     public static boolean isPartialRetry(SBuild build) {
-        TriggeredBy trigger = build.getTriggeredBy();
-        return trigger.isTriggeredByUser() ||
-                trigger.getParameters().getOrDefault("type", "").equals("retry");
+        return build.getTriggeredBy().getParameters().getOrDefault("type", "").equals("retry");
     }
 
     public static String buildID(SBuild build) {

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogNotificatorProcessingTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogNotificatorProcessingTest.java
@@ -161,29 +161,6 @@ public class DatadogNotificatorProcessingTest {
     }
 
     @Test
-    public void shouldHandleManualRetries() {
-        // Setup
-        SFinishedBuild prevAttempt = new MockBuild.Builder(1, PIPELINE).buildFinished();
-        SBuild pipelineRetry = new MockBuild.Builder(2, PIPELINE)
-                .isTriggeredByUser().withPreviousAttempt(prevAttempt).build();
-
-        when(buildsManagerMock.findBuildInstanceById(2)).thenReturn(pipelineRetry);
-
-        // When
-        notificator.onFinishedBuild(pipelineRetry);
-
-        // Then
-        ArgumentCaptor<Pipeline> pipelineCaptor = ArgumentCaptor.forClass(Pipeline.class);
-        verify(datadogClientMock, times(1))
-                .sendWebhook(pipelineCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
-
-        assertThat(pipelineCaptor.getValue().uniqueId()).isEqualTo(String.valueOf(2));
-        assertThat(pipelineCaptor.getValue().isPartialRetry()).isTrue();
-        assertThat(pipelineCaptor.getValue().previousAttempt()).isNotNull();
-        assertThat(pipelineCaptor.getValue().previousAttempt().id()).isEqualTo(buildID(prevAttempt));
-    }
-
-    @Test
     public void shouldHandleAutomaticRetries() {
         // Setup
         SFinishedBuild prevAttempt = new MockBuild.Builder(1, PIPELINE).buildFinished();


### PR DESCRIPTION
Right now we are considering a build as a partial retry if either:

- Is manually triggered by the user, as a user could manually retry a failed build
- Has "retry" as the "type" of its trigger, able to identify automatic retries on TC side

After speaking with TeamCity, it seems that the second condition is correct but the first condition (checking if the build is manually triggered by a user) is not always correct, as a user could start a **new** build chain manually. 