### PR TITLE
[CIAPP-5466] Send webhooks asynchronously and concurrently

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
@@ -65,10 +65,7 @@ public class BuildChainProcessor {
         ProjectParameters params = projectHandler.getProjectParameters(pipelineBuild);
         List<Webhook> webhooks = createWebhooks(pipelineBuild);
 
-        //TODO this currently sends all the webhook synchronously during build processing.
-        // TeamCity discouraged to do network calls during the processing of a build,
-        // so in future this will be replaced by asynchronous sending (CIAPP-5466).
-        datadogClient.sendWebhooks(webhooks, params.apiKey(), params.ddSite());
+        datadogClient.sendWebhooksAsync(webhooks, params.apiKey(), params.ddSite());
     }
 
     /**

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogConfiguration.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogConfiguration.java
@@ -8,16 +8,21 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 @Configuration
 public class DatadogConfiguration {
 
     private static final int MAX_RETRIES = 3;
     private static final int BACKOFF_SECONDS = 10;
     private static final int CONNECTION_TIMEOUT_MS = 10000; // 10 seconds
+    private static final int CLIENT_EXECUTOR_THREADS = 10;
 
     @Bean
     public DatadogClient datadogClient(ObjectMapper objectMapper, RestTemplate restTemplate) {
-        return new DatadogClient(restTemplate, objectMapper, new RetryInformation(MAX_RETRIES, BACKOFF_SECONDS));
+        ExecutorService executor = Executors.newFixedThreadPool(CLIENT_EXECUTOR_THREADS);
+        return new DatadogClient(restTemplate, objectMapper, new RetryInformation(MAX_RETRIES, BACKOFF_SECONDS), executor);
     }
 
     @Bean

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogNotifierProcessingTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogNotifierProcessingTest.java
@@ -132,7 +132,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
         PipelineWebhook expectedWebhook = new PipelineWebhook(
             DEFAULT_NAME,
@@ -159,7 +159,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
         PipelineWebhook expectedWebhook = new PipelineWebhook(
             DEFAULT_NAME,
@@ -190,7 +190,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
         List<Webhook> expectedWebhooks = Arrays.asList(
             new PipelineWebhook(
@@ -235,7 +235,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
         JobWebhook secondJobWebhook = new JobWebhook(
             DEFAULT_NAME,
@@ -299,7 +299,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
         // First job should be removed as it started before the pipeline (accounting for 3s offset)
         JobWebhook secondJobWebhook = new JobWebhook(
@@ -349,7 +349,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
         // Second job should be removed as the build is composite
         List<Webhook> expectedWebhooks = Arrays.asList(
@@ -396,7 +396,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
         // Second job should be removed as the build is personal
         List<Webhook> expectedWebhooks = Arrays.asList(
@@ -444,7 +444,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
         List<Webhook> expectedWebhooks = Arrays.asList(
             new PipelineWebhook(
@@ -489,7 +489,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
          JobWebhook jobWebhook = new JobWebhook(
              DEFAULT_NAME,
@@ -538,7 +538,7 @@ public class DatadogNotifierProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooks(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
 
         PipelineWebhook expectedPipelineWebhook = new PipelineWebhook(
             DEFAULT_NAME,


### PR DESCRIPTION
Currently we are sending webhooks (for jobs and pipelines) synchronously during build processing. TeamCity suggested to do that in an asynchronous executor so this PR implements that.