### PR TITLE
[CIAPP-5526] Remove possibility to specify email domain as a parameter

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -16,10 +16,6 @@ public class ProjectHandler {
     protected static final String DATADOG_API_KEY_PARAM = "datadog.ci.api.key";
     protected static final String DATADOG_SITE_PARAM = "datadog.ci.site";
 
-    // Clients are able to specify the email domain to be used if they are
-    // using the username styles not containing the email (USERID and NAME)
-    protected static final String EMAIL_DOMAIN_PARAM = "datadog.ci.email.domain";
-
     private final ProjectManager projectManager;
 
     public ProjectHandler(ProjectManager projectManager) {
@@ -45,16 +41,6 @@ public class ProjectHandler {
         return (ProjectEx) Optional.ofNullable(build.getProjectId())
             .map(projectManager::findProjectById)
             .orElse(projectManager.getRootProject());
-    }
-
-    public Optional<String> getEmailDomainParameter(SBuild build) {
-        ProjectEx project = getProject(build);
-        String emailDomain = project.getParameterValue(EMAIL_DOMAIN_PARAM);
-        if (emailDomain == null || emailDomain.isEmpty()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(emailDomain);
     }
 
     public static class ProjectParameters {

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/GitInformationExtractorTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/GitInformationExtractorTest.java
@@ -35,16 +35,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class GitInformationExtractorTest {
 
-    @Mock
-    private ProjectHandler projectHandlerMock;
-
-    private GitInformationExtractor gitInfoExtractor;
-
-    @Before
-    public void setUp() {
-        when(projectHandlerMock.getEmailDomainParameter(any())).thenReturn(Optional.empty());
-        gitInfoExtractor = new GitInformationExtractor(projectHandlerMock);
-    }
+    private final GitInformationExtractor gitInfoExtractor = new GitInformationExtractor();
 
     @Test
     public void shouldReturnEmptyIfNoRevisionIsFound() {
@@ -137,8 +128,8 @@ public class GitInformationExtractorTest {
         GitInfo expectedGitInfo = defaultGitInfo()
             .withAuthorName("John Doe")
             .withCommitterName("John Doe")
-            .withAuthorEmail("johndoe@" + DEFAULT_EMAIL_DOMAIN)
-            .withCommitterEmail("johndoe@" + DEFAULT_EMAIL_DOMAIN);
+            .withAuthorEmail("johndoe@teamcity")
+            .withCommitterEmail("johndoe@teamcity");
 
         assertThat(gitInfoOptional.get()).isEqualTo(expectedGitInfo);
     }
@@ -159,33 +150,8 @@ public class GitInformationExtractorTest {
         GitInfo expectedGitInfo = defaultGitInfo()
             .withAuthorName("johndoe")
             .withCommitterName("johndoe")
-            .withAuthorEmail("johndoe@" + DEFAULT_EMAIL_DOMAIN)
-            .withCommitterEmail("johndoe@" + DEFAULT_EMAIL_DOMAIN);
-
-        assertThat(gitInfoOptional.get()).isEqualTo(expectedGitInfo);
-    }
-
-    @Test
-    public void shouldUseProvidedEmailDomainForUserIDStyle() {
-        // Setup
-        String committerUsername = "johndoe";
-        SBuild build = new MockBuild.Builder(1, PIPELINE)
-            .addRevision(GIT_VCS, USERID.name(), committerUsername, EMPTY_AUTHOR_USERNAME)
-            .build();
-
-        when(projectHandlerMock.getEmailDomainParameter(build))
-            .thenReturn(Optional.of("datadog.com"));
-
-        // When
-        Optional<GitInfo> gitInfoOptional = gitInfoExtractor.extractGitInfo(build);
-
-        // Then: the provided email domain should be used
-        assertThat(gitInfoOptional).isNotEmpty();
-        GitInfo expectedGitInfo = defaultGitInfo()
-            .withAuthorName("johndoe")
-            .withCommitterName("johndoe")
-            .withAuthorEmail("johndoe@datadog.com")
-            .withCommitterEmail("johndoe@datadog.com");
+            .withAuthorEmail("johndoe@teamcity")
+            .withCommitterEmail("johndoe@teamcity");
 
         assertThat(gitInfoOptional.get()).isEqualTo(expectedGitInfo);
     }


### PR DESCRIPTION
After a discussion with product, if a client is using one of the username styles without an email, we will only add "@teamcity" after the user id/name 