### PR TITLE
[CIAPP-5556] Handling canceled builds in TeamCity

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/model/entities/JobWebhook.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/model/entities/JobWebhook.java
@@ -125,7 +125,8 @@ public class JobWebhook extends Webhook {
 
     public enum JobStatus {
         @JsonProperty("success") SUCCESS,
-        @JsonProperty("error") ERROR
+        @JsonProperty("error") ERROR,
+        @JsonProperty("canceled") CANCELED
     }
 
     public static class HostInfo {

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/model/entities/PipelineWebhook.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/model/entities/PipelineWebhook.java
@@ -91,7 +91,8 @@ public class PipelineWebhook extends Webhook {
 
     public enum PipelineStatus {
         @JsonProperty("success") SUCCESS,
-        @JsonProperty("error") ERROR
+        @JsonProperty("error") ERROR,
+        @JsonProperty("canceled") CANCELED
     }
 
 }

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/MockBuild.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/MockBuild.java
@@ -16,8 +16,10 @@ import jetbrains.buildServer.serverSide.BuildPromotionOwner;
 import jetbrains.buildServer.serverSide.BuildRevision;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.SBuildAgent;
+import jetbrains.buildServer.serverSide.SRunningBuild;
 import jetbrains.buildServer.serverSide.TriggeredBy;
 import jetbrains.buildServer.serverSide.dependency.BuildDependency;
+import jetbrains.buildServer.serverSide.userChanges.CanceledInfo;
 import jetbrains.buildServer.vcs.SVcsModification;
 import jetbrains.buildServer.vcs.VcsRootInstanceEx;
 import jetbrains.buildServer.vcs.impl.VcsModificationEx;
@@ -56,9 +58,9 @@ import static org.mockito.Mockito.when;
 // to create a mock build, returning default parameters unless overridden during creation.
 public class MockBuild {
 
-    public static SBuild fromBuilder(Builder b) {
+    public static SRunningBuild fromBuilder(Builder b) {
         // Build information mocks
-        SBuild buildMock = mock(SBuild.class);
+        SRunningBuild buildMock = mock(SRunningBuild.class);
         when(buildMock.getBuildId()).thenReturn(b.id);
         when(buildMock.getFullName()).thenReturn(b.fullName);
         when(buildMock.getBuildStatus()).thenReturn(b.status);
@@ -76,6 +78,7 @@ public class MockBuild {
         when(buildMock.isInternalError()).thenReturn(true);
         when(buildMock.getTriggeredBy()).thenReturn(b.triggeredBy);
         when(buildMock.getAgent()).thenReturn(b.agentMock);
+        when(buildMock.getCanceledInfo()).thenReturn(b.canceledInfo);
 
         // Build promotion mocks
         BuildPromotion buildPromotionMock = mock(BuildPromotion.class);
@@ -113,6 +116,7 @@ public class MockBuild {
         private final List<BuildRevision> revisions = new ArrayList<>();
         private final TriggeredBy triggeredBy = mock(TriggeredBy.class);
         private SBuildAgent agentMock;
+        private CanceledInfo canceledInfo;
 
         // Build Promotion customizable info
         private int dependentsNum;
@@ -173,6 +177,14 @@ public class MockBuild {
 
         public Builder withQueueDate(Date queueDate) {
             this.queueDate = queueDate;
+            return this;
+        }
+
+        public Builder withCanceledInfo(String comment) {
+            CanceledInfo canceledInfoMock = mock(CanceledInfo.class);
+            when(canceledInfoMock.getComment()).thenReturn(comment);
+            this.canceledInfo = canceledInfoMock;
+            this.status = Status.UNKNOWN;
             return this;
         }
 
@@ -249,7 +261,7 @@ public class MockBuild {
             return this;
         }
 
-        public SBuild build() {
+        public SRunningBuild build() {
             return fromBuilder(this);
         }
     }


### PR DESCRIPTION
What does this PR do?
---------------------

Our current plugin type is "notifier", which means that we are extending the TeamCity `NotificatorAdapter` class and overriding the methods there to define what to do when we are notified about builds succeeding or failing. With the current approach, there's no way to get a notification when a build is canceled instead, therefore I'm switching to define the plugin as a `BuildServerAdapter`, which allows us to be notified also on canceled builds (via the `buildInterrupted()` method). 

### Review checklist

- [x] I have added unit tests if applicable
- [x] (Only for critical changes) I have tested that the changes work in a TeamCity server
