### PR TITLE
[CIAPP-5346] Adding step to generate plugin zip from release tags workflows

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -102,8 +102,18 @@ jobs:
 
       - name: Generate Plugin Zip
         run: mvn package
-      - run: mkdir pluginZip && cp target/*.zip pluginZip/datadog-ci-integration-${{ github.ref_name }}.zip
-      - uses: actions/upload-artifact@v3
+      - name: Prepare the plugin for upload
+        run: |
+          PLUGIN_DIR="pluginZip"
+          PLUGIN_FILE="datadog-ci-integration-${{ github.ref_name }}"
+          PLUGIN_PATH="${PLUGIN_DIR}/${PLUGIN_FILE}.zip"
+          mkdir $PLUGIN_DIR
+          cp target/*.zip $PLUGIN_PATH
+          
+          echo "plugin_file=${PLUGIN_FILE}" >> $GITHUB_ENV
+          echo "plugin_path=${PLUGIN_PATH}" >> $GITHUB_ENV
+      - name: Upload the plugin result
+        uses: actions/upload-artifact@v3
         with:
-          name: datadog-ci-integration-${{ github.ref_name }}
-          path: pluginZip/datadog-ci-integration-${{ github.ref_name }}.zip
+          name: ${{env.plugin_file}}
+          path: ${{env.plugin_path}}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -2,90 +2,90 @@ name: Compile and Test changes
 on: [push]
 
 jobs:
-#  compile:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: actions/setup-java@v3
-#        with:
-#          java-version: '8'
-#          distribution: 'zulu'
-#      - name: Caching/Restoring Maven dependencies
-#        uses: actions/cache@v3
-#        with:
-#          path: ~/.m2/repository
-#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: |
-#            ${{ runner.os }}-maven-
-#      - name: Maven Compile
-#        run: mvn clean compile
-#
-#  test:
-#    needs: compile
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: actions/setup-java@v3
-#        with:
-#          java-version: '8'
-#          distribution: 'zulu'
-#      - name: Caching/Restoring Maven dependencies
-#        uses: actions/cache@v3
-#        with:
-#          path: ~/.m2/repository
-#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: |
-#            ${{ runner.os }}-maven-
-#      - name: Maven test
-#        run: mvn test
-#
-#  security-check:
-#    needs: test
-#    runs-on: ubuntu-latest
-#    permissions:
-#      actions: read
-#      contents: read
-#      security-events: write
-#
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        language: [ 'java' ]
-#
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v3
-#      - name: Caching/Restoring Maven dependencies
-#        uses: actions/cache@v3
-#        with:
-#          path: ~/.m2/repository
-#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: |
-#            ${{ runner.os }}-maven-
-#      - name: Initialize CodeQL
-#        uses: github/codeql-action/init@v2
-#        with:
-#          languages: ${{ matrix.language }}
-#
-#      - name: Autobuild
-#        uses: github/codeql-action/autobuild@v2
-#
-#      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-#      # If it fails, remove it and uncomment the following three lines.
-#
-#      # - run: |
-#      #   echo "Run, Build Application using script"
-#      #   ./location_of_script_within_repo/buildscript.sh
-#
-#      - name: Perform CodeQL Analysis
-#        uses: github/codeql-action/analyze@v2
-#        with:
-#          category: "/language:${{matrix.language}}"
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Caching/Restoring Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Maven Compile
+        run: mvn clean compile
+
+  test:
+    needs: compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Caching/Restoring Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Maven test
+        run: mvn test
+
+  security-check:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Caching/Restoring Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If it fails, remove it and uncomment the following three lines.
+
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"
 
   generate-plugin-zip:
-    #needs: security-check
+    needs: security-check
     runs-on: ubuntu-latest
-    #if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,55 +39,53 @@ jobs:
       - name: Maven test
         run: mvn test
 
-#  security-check:
-#    needs: test
-#    runs-on: ubuntu-latest
-#    permissions:
-#      actions: read
-#      contents: read
-#      security-events: write
-#
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        language: [ 'java' ]
-#
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v3
-#      - name: Caching/Restoring Maven dependencies
-#        uses: actions/cache@v3
-#        with:
-#          path: ~/.m2/repository
-#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: |
-#            ${{ runner.os }}-maven-
-#      - name: Initialize CodeQL
-#        uses: github/codeql-action/init@v2
-#        with:
-#          languages: ${{ matrix.language }}
-#
-#      - name: Autobuild
-#        uses: github/codeql-action/autobuild@v2
-#
-#      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-#      # If it fails, remove it and uncomment the following three lines.
-#
-#      # - run: |
-#      #   echo "Run, Build Application using script"
-#      #   ./location_of_script_within_repo/buildscript.sh
-#
-#      - name: Perform CodeQL Analysis
-#        uses: github/codeql-action/analyze@v2
-#        with:
-#          category: "/language:${{matrix.language}}"
+  security-check:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Caching/Restoring Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If it fails, remove it and uncomment the following three lines.
+
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"
 
   generate-plugin-zip:
-    # TO BE ADDED BACK
-    # needs: security-check
+    needs: security-check
     runs-on: ubuntu-latest
-    # TO BE ADDED BACK
-    # if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -81,3 +81,27 @@ jobs:
         uses: github/codeql-action/analyze@v2
         with:
           category: "/language:${{matrix.language}}"
+
+  generate-plugin-zip:
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Caching/Restoring Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Generate Plugin Zip
+        run: mvn package
+      - run: mkdir pluginZip && cp target/*.zip pluginZip
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Package
+          path: pluginZip

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -102,8 +102,8 @@ jobs:
 
       - name: Generate Plugin Zip
         run: mvn package
-      - run: mkdir pluginZip && cp target/*.zip pluginZip
+      - run: mkdir pluginZip && cp target/*.zip pluginZip/datadog-ci-integration-${{ github.ref_name }}.zip
       - uses: actions/upload-artifact@v3
         with:
-          name: datadog-ci-integration-${{ github.ref_name }}.zip
-          path: pluginZip
+          name: datadog-ci-integration-${{ github.ref_name }}
+          path: pluginZip/datadog-ci-integration-${{ github.ref_name }}.zip

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -106,5 +106,5 @@ jobs:
       - run: mkdir pluginZip && cp target/*.zip pluginZip
       - uses: actions/upload-artifact@v3
         with:
-          name: datadog-ci-integration-${{ $github.ref_name }}
+          name: datadog-ci-integration-${{ github.ref_name }}
           path: pluginZip

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -2,90 +2,90 @@ name: Compile and Test changes
 on: [push]
 
 jobs:
-  compile:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'zulu'
-      - name: Caching/Restoring Maven dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Maven Compile
-        run: mvn clean compile
-
-  test:
-    needs: compile
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'zulu'
-      - name: Caching/Restoring Maven dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Maven test
-        run: mvn test
-
-  security-check:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'java' ]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Caching/Restoring Maven dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
-
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-      # If it fails, remove it and uncomment the following three lines.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
-        with:
-          category: "/language:${{matrix.language}}"
+#  compile:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions/setup-java@v3
+#        with:
+#          java-version: '8'
+#          distribution: 'zulu'
+#      - name: Caching/Restoring Maven dependencies
+#        uses: actions/cache@v3
+#        with:
+#          path: ~/.m2/repository
+#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: |
+#            ${{ runner.os }}-maven-
+#      - name: Maven Compile
+#        run: mvn clean compile
+#
+#  test:
+#    needs: compile
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions/setup-java@v3
+#        with:
+#          java-version: '8'
+#          distribution: 'zulu'
+#      - name: Caching/Restoring Maven dependencies
+#        uses: actions/cache@v3
+#        with:
+#          path: ~/.m2/repository
+#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: |
+#            ${{ runner.os }}-maven-
+#      - name: Maven test
+#        run: mvn test
+#
+#  security-check:
+#    needs: test
+#    runs-on: ubuntu-latest
+#    permissions:
+#      actions: read
+#      contents: read
+#      security-events: write
+#
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        language: [ 'java' ]
+#
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v3
+#      - name: Caching/Restoring Maven dependencies
+#        uses: actions/cache@v3
+#        with:
+#          path: ~/.m2/repository
+#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: |
+#            ${{ runner.os }}-maven-
+#      - name: Initialize CodeQL
+#        uses: github/codeql-action/init@v2
+#        with:
+#          languages: ${{ matrix.language }}
+#
+#      - name: Autobuild
+#        uses: github/codeql-action/autobuild@v2
+#
+#      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+#      # If it fails, remove it and uncomment the following three lines.
+#
+#      # - run: |
+#      #   echo "Run, Build Application using script"
+#      #   ./location_of_script_within_repo/buildscript.sh
+#
+#      - name: Perform CodeQL Analysis
+#        uses: github/codeql-action/analyze@v2
+#        with:
+#          category: "/language:${{matrix.language}}"
 
   generate-plugin-zip:
-    needs: security-check
+    #needs: security-check
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
+    #if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -99,10 +99,11 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Generate Plugin Zip
         run: mvn package
       - run: mkdir pluginZip && cp target/*.zip pluginZip
       - uses: actions/upload-artifact@v3
         with:
-          name: datadog-ci-integration-${{ github.ref_name }}
+          name: datadog-ci-integration-${{ github.ref_name }}.zip
           path: pluginZip

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -85,7 +85,7 @@ jobs:
   generate-plugin-zip:
     needs: security-check
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,52 +39,55 @@ jobs:
       - name: Maven test
         run: mvn test
 
-  security-check:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'java' ]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Caching/Restoring Maven dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
-
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-      # If it fails, remove it and uncomment the following three lines.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
-        with:
-          category: "/language:${{matrix.language}}"
+#  security-check:
+#    needs: test
+#    runs-on: ubuntu-latest
+#    permissions:
+#      actions: read
+#      contents: read
+#      security-events: write
+#
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        language: [ 'java' ]
+#
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v3
+#      - name: Caching/Restoring Maven dependencies
+#        uses: actions/cache@v3
+#        with:
+#          path: ~/.m2/repository
+#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: |
+#            ${{ runner.os }}-maven-
+#      - name: Initialize CodeQL
+#        uses: github/codeql-action/init@v2
+#        with:
+#          languages: ${{ matrix.language }}
+#
+#      - name: Autobuild
+#        uses: github/codeql-action/autobuild@v2
+#
+#      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+#      # If it fails, remove it and uncomment the following three lines.
+#
+#      # - run: |
+#      #   echo "Run, Build Application using script"
+#      #   ./location_of_script_within_repo/buildscript.sh
+#
+#      - name: Perform CodeQL Analysis
+#        uses: github/codeql-action/analyze@v2
+#        with:
+#          category: "/language:${{matrix.language}}"
 
   generate-plugin-zip:
+    # TO BE ADDED BACK
+    # needs: security-check
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
+    # TO BE ADDED BACK
+    # if: github.ref_type == 'tag' && startsWith(github.ref_name, 'release-')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -103,5 +106,5 @@ jobs:
       - run: mkdir pluginZip && cp target/*.zip pluginZip
       - uses: actions/upload-artifact@v3
         with:
-          name: Package
+          name: datadog-ci-integration-${{ $github.ref_name }}
           path: pluginZip


### PR DESCRIPTION
What does this PR do?
---------------------

Adds a step to generate the plugin zip from the sources for release tags (i.e. protected tags starting with "release-"). Currently, creating a plugin release will involve the following step:

1. Create a new release tag based on the plugin version (e.g. release-0.0.1)
2. After the tag workflow is completed, download the plugin zip from the artifacts
3. Sign the plugin (to be checked yet)
4. Upload the plugin .zip to the JetBrains marketplace

### Review checklist

- [x] I have added unit tests if applicable
- [x] (Only for critical changes) I have tested that the changes work in a TeamCity server
