### PR TITLE
[CIAPP-5638] The plugin can be enabled/disabled at project level

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapter.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapter.java
@@ -28,12 +28,15 @@ public class DatadogServerAdapter extends BuildServerAdapter {
 
     private final BuildsManager buildsManager;
     private final BuildChainProcessor buildChainProcessor;
+    private final ProjectHandler projectHandler;
 
     public DatadogServerAdapter(EventDispatcher<BuildServerListener> eventListener,
                                 BuildsManager buildsManager,
-                                BuildChainProcessor buildChainProcessor) {
+                                BuildChainProcessor buildChainProcessor,
+                                ProjectHandler projectHandler) {
         this.buildsManager = buildsManager;
         this.buildChainProcessor = buildChainProcessor;
+        this.projectHandler = projectHandler;
 
         eventListener.addListener(this);
     }
@@ -49,6 +52,10 @@ public class DatadogServerAdapter extends BuildServerAdapter {
     }
 
     private void onBuildFinished(SRunningBuild build) {
+        if (!projectHandler.isPluginEnabled(build)) {
+            return;
+        }
+
         if (!isLastCompositeBuild(build)) {
             LOG.info(format("Ignoring build with id '%s' and name '%s'", build.getBuildId(), buildName(build)));
             return;

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -22,6 +22,7 @@ public class ProjectHandler {
 
     protected static final String DATADOG_API_KEY_PARAM = "datadog.ci.api.key";
     protected static final String DATADOG_SITE_PARAM = "datadog.ci.site";
+    protected static final String DATADOG_ENABLED_PARAM = "datadog.ci.enabled";
 
     private final ProjectManager projectManager;
 
@@ -41,6 +42,11 @@ public class ProjectHandler {
         }
 
         return new ProjectParameters(apiKey, ddSite);
+    }
+
+    public boolean isPluginEnabled(SBuild build) {
+        String enabled = getProject(build).getParameterValue(DATADOG_ENABLED_PARAM);
+        return Boolean.parseBoolean(enabled);
     }
 
     @Nonnull

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
@@ -86,12 +86,14 @@ public class DatadogServerAdapterProcessingTest {
     public void setUp() {
         when(buildServerMock.getRootUrl()).thenReturn(LOCALHOST);
         when(gitInfoExtractorMock.extractGitInfo(any())).thenReturn(Optional.empty());
-        when(projectHandlerMock.getProjectParameters(any()))
-            .thenReturn(new ProjectParameters(TEST_API_KEY, TEST_DD_SITE));
         when(serverSettings.getServerUUID()).thenReturn(DEFAULT_SERVER_ID);
 
+        when(projectHandlerMock.getProjectParameters(any()))
+            .thenReturn(new ProjectParameters(TEST_API_KEY, TEST_DD_SITE));
+        when(projectHandlerMock.isPluginEnabled(any())).thenReturn(true);
+
         BuildChainProcessor chainProcessor = new BuildChainProcessor(buildServerMock, datadogClientMock, projectHandlerMock, gitInfoExtractorMock, serverSettings);
-        datadogServerAdapter = new DatadogServerAdapter(eventListener, buildsManagerMock, chainProcessor);
+        datadogServerAdapter = new DatadogServerAdapter(eventListener, buildsManagerMock, chainProcessor, projectHandlerMock);
     }
 
     @Test
@@ -100,7 +102,17 @@ public class DatadogServerAdapterProcessingTest {
 
         datadogServerAdapter.buildFinished(jobBuild);
 
-        verifyZeroInteractions(projectHandlerMock, datadogClientMock, buildServerMock, buildsManagerMock);
+        verifyZeroInteractions(datadogClientMock, buildServerMock, buildsManagerMock);
+    }
+
+    @Test
+    public void shouldIgnoreBuildForProjectNotEnabled() {
+        when(projectHandlerMock.isPluginEnabled(any())).thenReturn(false);
+        SRunningBuild validBuild = new MockBuild.Builder(1, PIPELINE).build();
+
+        datadogServerAdapter.buildFinished(validBuild);
+
+        verifyZeroInteractions(datadogClientMock, buildServerMock, buildsManagerMock);
     }
 
     @Test
@@ -109,7 +121,7 @@ public class DatadogServerAdapterProcessingTest {
 
         datadogServerAdapter.buildFinished(personalBuild);
 
-        verifyZeroInteractions(projectHandlerMock, datadogClientMock, buildServerMock, buildsManagerMock);
+        verifyZeroInteractions(datadogClientMock, buildServerMock, buildsManagerMock);
     }
 
     @Test
@@ -120,7 +132,7 @@ public class DatadogServerAdapterProcessingTest {
 
         datadogServerAdapter.buildFinished(compositeBuildWithDependents);
 
-        verifyZeroInteractions(projectHandlerMock, datadogClientMock, buildServerMock, buildsManagerMock);
+        verifyZeroInteractions(datadogClientMock, buildServerMock, buildsManagerMock);
     }
 
     @Test
@@ -131,7 +143,7 @@ public class DatadogServerAdapterProcessingTest {
 
         datadogServerAdapter.buildFinished(pipelineBuild);
 
-        verifyZeroInteractions(projectHandlerMock, datadogClientMock, buildServerMock);
+        verifyZeroInteractions(datadogClientMock, buildServerMock);
     }
 
     @Test


### PR DESCRIPTION
What does this PR do?
---------------------

- Currently the plugin is enabled for all the projects as soon as is downloaded. With these changes the clients have more control and can enabled/disable the plugin at project-level by configuring the `datadog.ci.enabled` project parameter.

### Review checklist

- [x] I have added unit tests if applicable
- [x] (Only for critical changes) I have tested that the changes work in a TeamCity server
