### PR TITLE
Fix server in generated URLs

### DIFF
--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/TestUtils.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/TestUtils.java
@@ -32,6 +32,7 @@ public final class TestUtils {
     public static final String DEFAULT_PIPELINE_ID = "2";
     public static final String DEFAULT_BUILD_URL = "http://localhost/build/1";
     public static final String LOCALHOST = "http://localhost";
+    public static final String NON_DEFAULT_URL = "http://non-default-url";
     public static final String DEFAULT_PROJECT_ID = "Project ID";
     public static final String DEFAULT_REPO_URL = "repository-url.com";
     public static final String DEFAULT_BRANCH = "main";
@@ -60,6 +61,10 @@ public final class TestUtils {
 
     public static String defaultUrl(SBuild build) {
         return format("%s/build/%s", LOCALHOST, build.getBuildId());
+    }
+
+    public static String nonDefaultUrl(SBuild build) {
+        return format("%s/build/%s", NON_DEFAULT_URL, build.getBuildId());
     }
 
     public static HostInfo defaultHostInfo() {


### PR DESCRIPTION
What does this PR do?
---------------------

- Fixes the problem for which URLs were being generated with `localhost` as host in the version 0.0.2 (that has been disabled).
- Fixes the validation of schema not present in the root URL, defaulting it to `http`.
- Changes the test to reproduce the issue of setting `localhost` as host and then validate that the fixes work.

### Review checklist

- [x] I have added unit tests if applicable
- [x] (Only for critical changes) I have tested that the changes work in a TeamCity server
