### PR TITLE
Add debug log when plugin is not enabled

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapter.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapter.java
@@ -53,6 +53,7 @@ public class DatadogServerAdapter extends BuildServerAdapter {
 
     private void onBuildFinished(SRunningBuild build) {
         if (!projectHandler.isPluginEnabled(build)) {
+            LOG.debug(format("Plugin not enabled"));
             return;
         }
 


### PR DESCRIPTION
What does this PR do?
---------------------

- Adds a debug level log when the plugin is not enabled.

### Review checklist

- [x] I have added unit tests if applicable
- [x] (Only for critical changes) I have tested that the changes work in a TeamCity server
