### PR TITLE
Batch pipeline events when sending to DataDog api endpoint

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
@@ -82,7 +82,7 @@ public class BuildChainProcessor {
         ProjectParameters params = projectHandler.getProjectParameters(pipelineBuild);
         List<Webhook> webhooks = createWebhooks(pipelineBuild);
 
-        datadogClient.sendWebhooksAsync(webhooks, params.apiKey(), params.ddSite());
+        datadogClient.sendWebhooksAsync(webhooks, params.apiKey(), params.ddSite(), params.batchSize());
     }
 
     /**

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
@@ -31,7 +31,6 @@ public class DatadogClient {
     private static final Logger LOG = Logger.getInstance(DatadogClient.class.getName());
     private static final String TEAMCITY_PROVIDER = "teamcity";
     private static final String WEBHOOK_INTAKE_BASE_URL = "https://webhook-intake.%s/api/v2/webhook";
-    private static final int DEFAULT_BATCH_SIZE = 20;
 
     protected static final String DD_API_KEY_HEADER = "DD-API-KEY";
     protected static final String DD_CI_PROVIDER_HEADER = "DD-CI-PROVIDER-NAME";

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
@@ -48,10 +48,6 @@ public class DatadogClient {
         this.clientExecutor = clientExecutor;
     }
 
-    public void sendWebhooksAsync(List<Webhook> webhooks, String apiKey, String ddSite) {
-        sendWebhooksAsync(webhooks, apiKey, ddSite, DEFAULT_BATCH_SIZE);
-    }
-    
     @VisibleForTesting
     protected void sendWebhooksAsync(List<Webhook> webhooks, String apiKey, String ddSite, int batchSize) {
         // Split webhooks into batches and send each batch asynchronously

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
@@ -31,6 +31,7 @@ public class DatadogClient {
     private static final Logger LOG = Logger.getInstance(DatadogClient.class.getName());
     private static final String TEAMCITY_PROVIDER = "teamcity";
     private static final String WEBHOOK_INTAKE_BASE_URL = "https://webhook-intake.%s/api/v2/webhook";
+    private static final int DEFAULT_BATCH_SIZE = 20;
 
     protected static final String DD_API_KEY_HEADER = "DD-API-KEY";
     protected static final String DD_CI_PROVIDER_HEADER = "DD-CI-PROVIDER-NAME";
@@ -48,15 +49,17 @@ public class DatadogClient {
     }
 
     public void sendWebhooksAsync(List<Webhook> webhooks, String apiKey, String ddSite) {
-        // For now, send each webhook individually as a single-element batch
-        // This maintains current behavior while preparing for true batching
-        for (Webhook webhook : webhooks) {
-            clientExecutor.submit(() -> sendWebhookBatchWithRetries(singletonList(webhook), apiKey, ddSite));
-        }
+        sendWebhooksAsync(webhooks, apiKey, ddSite, DEFAULT_BATCH_SIZE);
     }
     
-    private static List<Webhook> singletonList(Webhook webhook) {
-        return java.util.Collections.singletonList(webhook);
+    @VisibleForTesting
+    protected void sendWebhooksAsync(List<Webhook> webhooks, String apiKey, String ddSite, int batchSize) {
+        // Split webhooks into batches and send each batch asynchronously
+        for (int i = 0; i < webhooks.size(); i += batchSize) {
+            int end = Math.min(i + batchSize, webhooks.size());
+            List<Webhook> batch = webhooks.subList(i, end);
+            clientExecutor.submit(() -> sendWebhookBatchWithRetries(batch, apiKey, ddSite));
+        }
     }
 
     @VisibleForTesting

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClient.java
@@ -48,39 +48,47 @@ public class DatadogClient {
     }
 
     public void sendWebhooksAsync(List<Webhook> webhooks, String apiKey, String ddSite) {
+        // For now, send each webhook individually as a single-element batch
+        // This maintains current behavior while preparing for true batching
         for (Webhook webhook : webhooks) {
-            clientExecutor.submit(() -> sendWebhookWithRetries(webhook, apiKey, ddSite));
+            clientExecutor.submit(() -> sendWebhookBatchWithRetries(singletonList(webhook), apiKey, ddSite));
         }
+    }
+    
+    private static List<Webhook> singletonList(Webhook webhook) {
+        return java.util.Collections.singletonList(webhook);
     }
 
     @VisibleForTesting
-    protected boolean sendWebhookWithRetries(Webhook webhook, String apiKey, String ddSite) {
+    protected boolean sendWebhookBatchWithRetries(List<Webhook> webhookBatch, String apiKey, String ddSite) {
         String url = format(WEBHOOK_INTAKE_BASE_URL, ddSite);
-        String payload = serialize(webhook);
+        String payload = serializeBatch(webhookBatch);
         HttpEntity<String> request = new HttpEntity<>(payload, getHeaders(apiKey));
+        
+        String batchDescription = getBatchDescription(webhookBatch);
 
         int currentAttempt = 0;
         while (currentAttempt <= retryInfo.maxRetries) {
             try {
                 ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, request, String.class);
                 if (response.getStatusCode().is2xxSuccessful()) {
-                    LOG.info(format("Successfully sent webhook with id '%s' to '%s'", webhook.id(), url));
+                    LOG.info(format("Successfully sent webhook batch %s to '%s'", batchDescription, url));
                     return true;
                 } else if (response.getStatusCode().is5xxServerError()) {
-                    LOG.warn(format("Could not send webhook with id '%s' to '%s'. " +
+                    LOG.warn(format("Could not send webhook batch %s to '%s'. " +
                                     "Status code: '%s', Retry number %d/%d",
-                            webhook.id(), url, response.getStatusCode(), currentAttempt, retryInfo.maxRetries));
+                            batchDescription, url, response.getStatusCode(), currentAttempt, retryInfo.maxRetries));
 
                     sleepSeconds(retryInfo.backoffSeconds);
                 } else {
                     // Status code is different from 5xx, so we won't retry
-                    LOG.warn(format("Could not send webhook with id '%s' to url '%s'. " +
-                                    "Status code: '%s'.", webhook.id(), url, response.getStatusCode()));
+                    LOG.warn(format("Could not send webhook batch %s to url '%s'. " +
+                                    "Status code: '%s'.", batchDescription, url, response.getStatusCode()));
                     return false;
                 }
             } catch (RestClientException ex) {
-                LOG.error(format("Exception occurred while sending webhooks with id '%s' to url '%s'. " +
-                                "Retry number %d/%d: ", webhook.id(), url, currentAttempt, retryInfo.maxRetries), ex);
+                LOG.error(format("Exception occurred while sending webhook batch %s to url '%s'. " +
+                                "Retry number %d/%d: ", batchDescription, url, currentAttempt, retryInfo.maxRetries), ex);
                 sleepSeconds(retryInfo.backoffSeconds);
             }
 
@@ -88,6 +96,13 @@ public class DatadogClient {
         }
 
         return false;
+    }
+    
+    private String getBatchDescription(List<Webhook> webhookBatch) {
+        return format("batch of %d webhook%s, starting with id '%s'", 
+            webhookBatch.size(), 
+            webhookBatch.size() == 1 ? "" : "s",
+            webhookBatch.get(0).id());
     }
 
     private HttpHeaders getHeaders(String apiKey) {
@@ -98,11 +113,12 @@ public class DatadogClient {
         return headers;
     }
 
-    private String serialize(Webhook entity) {
+    private String serializeBatch(List<Webhook> webhookBatch) {
         try {
-            return objectMapper.writeValueAsString(entity);
+            // Always serialize as array - Datadog API accepts both single objects and arrays
+            return objectMapper.writeValueAsString(webhookBatch);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(format("Could not serialize the content of the entity: %s", entity), e);
+            throw new RuntimeException(format("Could not serialize the webhook batch: %s", webhookBatch), e);
         }
     }
 

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -28,6 +28,9 @@ public class ProjectHandler {
     protected static final String DATADOG_API_KEY_PARAM = "datadog.ci.api.key";
     protected static final String DATADOG_SITE_PARAM = "datadog.ci.site";
     protected static final String DATADOG_ENABLED_PARAM = "datadog.ci.enabled";
+    protected static final String DATADOG_BATCH_SIZE_PARAM = "datadog.ci.batch.size";
+    
+    private static final int DEFAULT_BATCH_SIZE = 20;
 
     private final ProjectManager projectManager;
 
@@ -45,8 +48,10 @@ public class ProjectHandler {
                     format("Could not find required property '%s' for project '%s'. Project parameters: %s",
                             DATADOG_SITE_PARAM, project.getName(), project.getParameters()));
         }
+        
+        int batchSize = getBatchSize(project);
 
-        return new ProjectParameters(apiKey, ddSite);
+        return new ProjectParameters(apiKey, ddSite, batchSize);
     }
 
     public boolean isPluginEnabled(SBuild build) {
@@ -79,14 +84,34 @@ public class ProjectHandler {
 
         return resolved.getResult();
     }
+    
+    private int getBatchSize(ProjectEx project) {
+        String batchSizeStr = project.getParameterValue(DATADOG_BATCH_SIZE_PARAM);
+        if (batchSizeStr == null || batchSizeStr.trim().isEmpty()) {
+            return DEFAULT_BATCH_SIZE;
+        }
+        
+        try {
+            int batchSize = Integer.parseInt(batchSizeStr.trim());
+            if (batchSize > 0) {
+                return batchSize;
+            }
+        } catch (NumberFormatException e) {}
+        
+        LOG.warn(format("Invalid batch size value '%s' for project '%s'. Using default: %d", 
+            batchSizeStr, project.getName(), DEFAULT_BATCH_SIZE));
+        return DEFAULT_BATCH_SIZE;
+    }
 
     public static class ProjectParameters {
         private final String apiKey;
         private final String ddSite;
+        private final int batchSize;
 
-        public ProjectParameters(String apiKey, String ddSite) {
+        public ProjectParameters(String apiKey, String ddSite, int batchSize) {
             this.apiKey = apiKey;
             this.ddSite = ddSite;
+            this.batchSize = batchSize;
         }
 
         public String apiKey() {
@@ -95,6 +120,10 @@ public class ProjectHandler {
 
         public String ddSite() {
             return ddSite;
+        }
+        
+        public int batchSize() {
+            return batchSize;
         }
     }
 }

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClientTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClientTest.java
@@ -119,9 +119,9 @@ public class DatadogClientTest {
         when(restTemplateMock.exchange(anyString(), eq(POST), any(), Matchers.<Class<String>>any()))
             .thenReturn(ResponseEntity.ok("Successful Request"));
 
-        // When
+        // When - use batch size of 1 to send each webhook separately for this test
         List<Webhook> webhooks = Arrays.asList(completeJob(), completePipeline());
-        datadogClient.sendWebhooksAsync(webhooks, TEST_API_KEY, TEST_DD_SITE);
+        datadogClient.sendWebhooksAsync(webhooks, TEST_API_KEY, TEST_DD_SITE, 1);
 
         // Then
         verify(restTemplateMock, timeout(TEST_TIMEOUT_MS).times(2))
@@ -135,6 +135,32 @@ public class DatadogClientTest {
             .anyMatch(req -> removeWhitespaces(req.getBody()).equals(removeWhitespaces(expectedJobJson)))
             .anyMatch(req -> removeWhitespaces(req.getBody()).equals(removeWhitespaces(expectedPipelineJson)));
 
+    }
+
+    @Test
+    public void shouldBatchWebhooksIntoMultipleRequests() {
+        // Setup
+        when(restTemplateMock.exchange(anyString(), eq(POST), any(), Matchers.<Class<String>>any()))
+            .thenReturn(ResponseEntity.ok("Successful Request"));
+
+        // When - send 3 webhooks with batch size of 2 (should result in 2 requests: 2+1)
+        List<Webhook> webhooks = Arrays.asList(defaultPipeline(), completeJob(), completePipeline());
+        datadogClient.sendWebhooksAsync(webhooks, TEST_API_KEY, TEST_DD_SITE, 2);
+
+        // Then - verify 2 HTTP requests were made
+        verify(restTemplateMock, timeout(TEST_TIMEOUT_MS).times(2))
+            .exchange(eq(TEST_WEBHOOK_INTAKE), eq(POST), requestCaptor.capture(), eq(String.class));
+
+        // Verify batching: first batch should have 2 webhooks, second batch should have 1
+        List<HttpEntity<String>> requests = requestCaptor.getAllValues();
+        assertThat(requests).hasSize(2);
+        
+        // Count webhooks in each batch by counting array elements
+        for (HttpEntity<String> request : requests) {
+            String body = request.getBody();
+            // Simple check: body should start with '[' and end with ']'
+            assertThat(body.trim()).startsWith("[").endsWith("]");
+        }
     }
 
     @Test

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClientTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClientTest.java
@@ -28,6 +28,9 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -142,7 +145,7 @@ public class DatadogClientTest {
 
         // When
         PipelineWebhook pipelineWebhook = defaultPipeline();
-        boolean successful = datadogClient.sendWebhookWithRetries(pipelineWebhook, TEST_API_KEY, TEST_DD_SITE);
+        boolean successful = datadogClient.sendWebhookBatchWithRetries(singletonList(pipelineWebhook), TEST_API_KEY, TEST_DD_SITE);
 
         // Then
         verify(restTemplateMock, times(1))
@@ -170,7 +173,7 @@ public class DatadogClientTest {
 
         // When
         PipelineWebhook pipelineWebhook = defaultPipeline();
-        boolean successful = datadogClient.sendWebhookWithRetries(pipelineWebhook, TEST_API_KEY, TEST_DD_SITE);
+        boolean successful = datadogClient.sendWebhookBatchWithRetries(singletonList(pipelineWebhook), TEST_API_KEY, TEST_DD_SITE);
 
         // Then
         verify(restTemplateMock, times(2))
@@ -198,7 +201,7 @@ public class DatadogClientTest {
 
         // When
         PipelineWebhook pipelineWebhook = defaultPipeline();
-        boolean successful = datadogClient.sendWebhookWithRetries(pipelineWebhook, TEST_API_KEY, TEST_DD_SITE);
+        boolean successful = datadogClient.sendWebhookBatchWithRetries(singletonList(pipelineWebhook), TEST_API_KEY, TEST_DD_SITE);
 
         // Then
         verify(restTemplateMock, times(2))
@@ -226,7 +229,7 @@ public class DatadogClientTest {
 
         // When
         PipelineWebhook pipelineWebhook = defaultPipeline();
-        boolean successful = datadogClient.sendWebhookWithRetries(pipelineWebhook, mockApiKey, "datad0g.com");
+        boolean successful = datadogClient.sendWebhookBatchWithRetries(singletonList(pipelineWebhook), mockApiKey, "datad0g.com");
 
         // Then
         verify(restTemplateMock, times(1))
@@ -243,7 +246,7 @@ public class DatadogClientTest {
 
         // When
         PipelineWebhook pipelineWebhook = defaultPipeline();
-        boolean successful = datadogClient.sendWebhookWithRetries(pipelineWebhook, mockApiKey, "datad0g.com");
+        boolean successful = datadogClient.sendWebhookBatchWithRetries(singletonList(pipelineWebhook), mockApiKey, "datad0g.com");
 
         // Then
         verify(restTemplateMock, times(3)) // 1 normal and 2 retries
@@ -259,7 +262,7 @@ public class DatadogClientTest {
 
         // When
         PipelineWebhook pipelineWebhook = completePipeline();
-        boolean successful = datadogClient.sendWebhookWithRetries(pipelineWebhook, TEST_API_KEY, TEST_DD_SITE);
+        boolean successful = datadogClient.sendWebhookBatchWithRetries(singletonList(pipelineWebhook), TEST_API_KEY, TEST_DD_SITE);
 
         // Then
         verify(restTemplateMock, times(1))
@@ -286,7 +289,7 @@ public class DatadogClientTest {
 
         // When
         JobWebhook jobWebhook = completeJob();
-        boolean successful = datadogClient.sendWebhookWithRetries(jobWebhook, TEST_API_KEY, TEST_DD_SITE);
+        boolean successful = datadogClient.sendWebhookBatchWithRetries(singletonList(jobWebhook), TEST_API_KEY, TEST_DD_SITE);
 
         // Then
         verify(restTemplateMock, times(1))

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClientTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogClientTest.java
@@ -103,7 +103,7 @@ public class DatadogClientTest {
 
         // When
         PipelineWebhook pipelineWebhook = defaultPipeline();
-        datadogClient.sendWebhooksAsync(singletonList(pipelineWebhook), TEST_API_KEY, TEST_DD_SITE);
+        datadogClient.sendWebhooksAsync(singletonList(pipelineWebhook), TEST_API_KEY, TEST_DD_SITE, 20);
 
         verify(restTemplateMock, timeout(TEST_TIMEOUT_MS).times(1))
             .exchange(eq(TEST_WEBHOOK_INTAKE), eq(POST), requestCaptor.capture(), eq(String.class));

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
@@ -91,7 +91,7 @@ public class DatadogServerAdapterProcessingTest {
         when(serverSettings.getServerUUID()).thenReturn(DEFAULT_SERVER_ID);
 
         when(projectHandlerMock.getProjectParameters(any()))
-            .thenReturn(new ProjectParameters(TEST_API_KEY, TEST_DD_SITE));
+            .thenReturn(new ProjectParameters(TEST_API_KEY, TEST_DD_SITE, 20));
         when(projectHandlerMock.isPluginEnabled(any())).thenReturn(true);
 
         BuildChainProcessor chainProcessor = new BuildChainProcessor(buildServerMock, datadogClientMock, projectHandlerMock, gitInfoExtractorMock, serverSettings);
@@ -159,7 +159,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         PipelineWebhook expectedWebhook = new PipelineWebhook(
             DEFAULT_NAME,
@@ -186,7 +186,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         PipelineWebhook expectedWebhook = new PipelineWebhook(
             DEFAULT_NAME,
@@ -217,7 +217,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         List<Webhook> expectedWebhooks = Arrays.asList(
             new PipelineWebhook(
@@ -262,7 +262,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         JobWebhook secondJobWebhook = new JobWebhook(
             DEFAULT_NAME,
@@ -326,7 +326,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         // First job should be removed as it started before the pipeline (accounting for 3s offset)
         JobWebhook secondJobWebhook = new JobWebhook(
@@ -376,7 +376,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         // Second job should be removed as the build is composite
         List<Webhook> expectedWebhooks = Arrays.asList(
@@ -423,7 +423,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         // Second job should be removed as the build is personal
         List<Webhook> expectedWebhooks = Arrays.asList(
@@ -471,7 +471,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         List<Webhook> expectedWebhooks = Arrays.asList(
             new PipelineWebhook(
@@ -516,7 +516,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
          JobWebhook jobWebhook = new JobWebhook(
              DEFAULT_NAME,
@@ -565,7 +565,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         PipelineWebhook expectedPipelineWebhook = new PipelineWebhook(
             DEFAULT_NAME,
@@ -606,7 +606,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         PipelineWebhook expectedWebhook = new PipelineWebhook(
             DEFAULT_NAME,
@@ -639,7 +639,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         // Job webhook should not be sent as it has an invalid end date
         PipelineWebhook expectedWebhook = new PipelineWebhook(
@@ -677,7 +677,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-                .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+                .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         List<Webhook> expectedWebhooks = Arrays.asList(
                 new PipelineWebhook(
@@ -723,7 +723,7 @@ public class DatadogServerAdapterProcessingTest {
 
         // Then
         verify(datadogClientMock, times(1))
-                .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+                .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(20));
 
         List<Webhook> expectedWebhooks = Arrays.asList(
                 new PipelineWebhook(
@@ -748,5 +748,20 @@ public class DatadogServerAdapterProcessingTest {
 
         List<Webhook> webhooksSent = webhooksCaptor.getValue();
         assertThat(webhooksSent).hasSize(2).hasSameElementsAs(expectedWebhooks);
+    }
+
+    @Test
+    public void shouldPassBatchSizeParameterToDatadogClient() {
+        int customBatchSize = 2;
+        when(projectHandlerMock.getProjectParameters(any()))
+            .thenReturn(new ProjectParameters(TEST_API_KEY, TEST_DD_SITE, customBatchSize));
+
+        SRunningBuild pipelineBuild = new MockBuild.Builder(1, PIPELINE).build();
+        when(buildsManagerMock.findBuildInstanceById(1)).thenReturn(pipelineBuild);
+
+        datadogServerAdapter.buildFinished(pipelineBuild);
+
+        verify(datadogClientMock, times(1))
+            .sendWebhooksAsync(any(), eq(TEST_API_KEY), eq(TEST_DD_SITE), eq(customBatchSize));
     }
 }

--- a/datadog-ci-integration-server/src/test/resources/complete-job.json
+++ b/datadog-ci-integration-server/src/test/resources/complete-job.json
@@ -1,3 +1,4 @@
+[
 {
   "level": "job",
   "name": "Full Name",
@@ -33,3 +34,4 @@
     "domain": "provider"
   }
 }
+]

--- a/datadog-ci-integration-server/src/test/resources/complete-pipeline.json
+++ b/datadog-ci-integration-server/src/test/resources/complete-pipeline.json
@@ -1,3 +1,4 @@
+[
 {
   "level": "pipeline",
   "name": "Full Name",
@@ -22,3 +23,4 @@
   "partial_retry": false,
   "status": "success"
 }
+]

--- a/datadog-ci-integration-server/src/test/resources/default-pipeline.json
+++ b/datadog-ci-integration-server/src/test/resources/default-pipeline.json
@@ -1,3 +1,4 @@
+[
 {
   "level": "pipeline",
   "name": "Full Name",
@@ -9,3 +10,4 @@
   "partial_retry": false,
   "status": "success"
 }
+]


### PR DESCRIPTION
Support batches of pipeline events for the Datadog api.
---------------------

- Pipeline events are now batched up for the datadog api endpoint
- A default batch size of 20 is hard-coded

This reduces overhead and improves perfornance.
This becomes important when TeamCity pipelines start sending individual build steps, as in PR #57



### Review checklist

- [x] I have added unit tests if applicable
- [] (Only for critical changes) I have tested that the changes work in a TeamCity server
