### PR TITLE
Allow build chains that don't end in a composite build

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
@@ -99,7 +99,7 @@ public class BuildChainProcessor {
         ChainMembership chainInfo = gatherChainMembers(pipelineBuild);
         
         LOG.info(format("Found %d builds in trigger chain", chainInfo.acceptedBuilds.size()));
-        LOG.info(format("Chain start time: %s", chainInfo.minStartTime));
+        LOG.info(format("Chain queue time: %s", chainInfo.minQueueTime));
         LOG.info(format("Chain end time: %s", chainInfo.maxFinishTime));
         
         // Create pipeline webhook with expanded timing from entire chain
@@ -123,11 +123,11 @@ public class BuildChainProcessor {
     }
 
     private PipelineWebhook createPipelineWebhook(SBuild pipelineBuild, ChainMembership chainInfo) {
-        // Use chain timing instead of just the composite build's timing
+        // Use chain timing (from earliest queue time to latest finish time)
         PipelineWebhook pipelineWebhook = new PipelineWebhook(
             buildName(pipelineBuild),
             buildURL(pipelineBuild),
-            toRFC3339(chainInfo.minStartTime),
+            toRFC3339(chainInfo.minQueueTime),
             toRFC3339(chainInfo.maxFinishTime),
             buildID(pipelineBuild),
             String.valueOf(pipelineBuild.getBuildId()),
@@ -164,7 +164,7 @@ public class BuildChainProcessor {
         Map<Long, SBuild> acceptedBuilds = new HashMap<>();
         acceptedBuilds.put(pipelineBuild.getBuildId(), pipelineBuild);
         
-        Date minStartTime = pipelineBuild.getStartDate();
+        Date minQueueTime = pipelineBuild.getQueuedDate();
         Date maxFinishTime = pipelineBuild.getFinishDate();
         
         // Get all dependencies (flattened graph)
@@ -198,9 +198,9 @@ public class BuildChainProcessor {
                     LOG.info(format("Accepting build #%d '%s' into chain", dependency.getBuildId(), buildName(dependency)));
                     acceptedBuilds.put(dependency.getBuildId(), dependency);
                     
-                    // Update min/max times
-                    if (dependency.getStartDate().before(minStartTime)) {
-                        minStartTime = dependency.getStartDate();
+                    // Update min/max times (use queue time to include time spent waiting)
+                    if (dependency.getQueuedDate().before(minQueueTime)) {
+                        minQueueTime = dependency.getQueuedDate();
                     }
                     if (dependency.getFinishDate() != null && dependency.getFinishDate().after(maxFinishTime)) {
                         maxFinishTime = dependency.getFinishDate();
@@ -220,7 +220,7 @@ public class BuildChainProcessor {
             .filter(build -> build.getBuildId() != pipelineBuild.getBuildId())
             .collect(toList());
             
-        return new ChainMembership(chainMembers, minStartTime, maxFinishTime);
+        return new ChainMembership(chainMembers, minQueueTime, maxFinishTime);
     }
     
     /**
@@ -264,12 +264,12 @@ public class BuildChainProcessor {
      */
     private static class ChainMembership {
         final List<SBuild> acceptedBuilds;
-        final Date minStartTime;
+        final Date minQueueTime;
         final Date maxFinishTime;
         
-        ChainMembership(List<SBuild> acceptedBuilds, Date minStartTime, Date maxFinishTime) {
+        ChainMembership(List<SBuild> acceptedBuilds, Date minQueueTime, Date maxFinishTime) {
             this.acceptedBuilds = acceptedBuilds;
-            this.minStartTime = minStartTime;
+            this.minQueueTime = minQueueTime;
             this.maxFinishTime = maxFinishTime;
         }
     }

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -79,6 +80,9 @@ public class BuildChainProcessor {
     }
 
     public void process(SBuild pipelineBuild) {
+        LOG.info("=== Processing Pipeline Build ===");
+        logTriggeredByInfo(pipelineBuild, "PIPELINE");
+        
         ProjectParameters params = projectHandler.getProjectParameters(pipelineBuild);
         List<Webhook> webhooks = createWebhooks(pipelineBuild);
 
@@ -89,10 +93,27 @@ public class BuildChainProcessor {
      * Creates all the webhooks for a build chain. There will be 1 pipeline webhook for the final
      * composite build and <em>N</em> webhooks for the eligible job builds in the chain.
      */
-    private List<Webhook> createWebhooks(SBuild pipelineBuild) {
-        PipelineWebhook pipelineWebhook = createPipelineWebhook(pipelineBuild);
+    List<Webhook> createWebhooks(SBuild pipelineBuild) {
+        // First, gather all builds in the chain to get accurate timing information
+        LOG.info("=== Processing Dependencies ===");
+        ChainMembership chainInfo = gatherChainMembers(pipelineBuild);
+        
+        LOG.info(format("Found %d builds in trigger chain", chainInfo.acceptedBuilds.size()));
+        LOG.info(format("Chain start time: %s", chainInfo.minStartTime));
+        LOG.info(format("Chain end time: %s", chainInfo.maxFinishTime));
+        
+        // Create pipeline webhook with expanded timing from entire chain
+        PipelineWebhook pipelineWebhook = createPipelineWebhook(pipelineBuild, chainInfo);
         List<Webhook> webhooks = new ArrayList<>(singletonList(pipelineWebhook));
-        webhooks.addAll(createJobWebhooks(pipelineBuild));
+        
+        // Create job webhooks for all accepted chain members
+        String pipelineName = buildName(pipelineBuild);
+        String pipelineID = buildID(pipelineBuild);
+        List<JobWebhook> jobWebhooks = chainInfo.acceptedBuilds.stream()
+            .filter(build -> !shouldBeIgnored(build))
+            .map(job -> createJobWebhook(job, pipelineName, pipelineID))
+            .collect(toList());
+        webhooks.addAll(jobWebhooks);
 
         // Adding git information to all webhooks
         Optional<GitInfo> gitInfoOptional = gitInformationExtractor.extractGitInfo(pipelineBuild);
@@ -101,12 +122,13 @@ public class BuildChainProcessor {
         return webhooks;
     }
 
-    private PipelineWebhook createPipelineWebhook(SBuild pipelineBuild) {
+    private PipelineWebhook createPipelineWebhook(SBuild pipelineBuild, ChainMembership chainInfo) {
+        // Use chain timing instead of just the composite build's timing
         PipelineWebhook pipelineWebhook = new PipelineWebhook(
             buildName(pipelineBuild),
             buildURL(pipelineBuild),
-            toRFC3339(pipelineBuild.getStartDate()),
-            toRFC3339(pipelineBuild.getFinishDate()),
+            toRFC3339(chainInfo.minStartTime),
+            toRFC3339(chainInfo.maxFinishTime),
             buildID(pipelineBuild),
             String.valueOf(pipelineBuild.getBuildId()),
             isPartialRetry(pipelineBuild),
@@ -132,26 +154,130 @@ public class BuildChainProcessor {
         throw new IllegalArgumentException("Pipeline status not recognized: " + buildStatus);
     }
 
-    private List<JobWebhook> createJobWebhooks(SBuild pipelineBuild) {
-        String pipelineName = buildName(pipelineBuild);
-        String pipelineID = buildID(pipelineBuild);
-        Date pipelineStartWithOffset = pipelineStartWithOffset(pipelineBuild);
-
-        return pipelineBuild.getBuildPromotion().getAllDependencies().stream()
+    /**
+     * Recursively gathers all builds that are part of the same trigger chain.
+     * Handles diamond-shaped dependencies where a build might be visited before its triggering parent is accepted.
+     * Also tracks min/max times across all accepted builds.
+     */
+    private ChainMembership gatherChainMembers(SBuild pipelineBuild) {
+        // Start with the pipeline build as accepted
+        Map<Long, SBuild> acceptedBuilds = new HashMap<>();
+        acceptedBuilds.put(pipelineBuild.getBuildId(), pipelineBuild);
+        
+        Date minStartTime = pipelineBuild.getStartDate();
+        Date maxFinishTime = pipelineBuild.getFinishDate();
+        
+        // Get all dependencies (flattened graph)
+        List<SBuild> allDependencies = pipelineBuild.getBuildPromotion().getAllDependencies().stream()
             .map(BuildPromotion::getAssociatedBuild)
             .filter(Objects::nonNull)
-            .filter(build -> !shouldBeIgnored(build, pipelineStartWithOffset))
-            .map(job -> createJobWebhook(job, pipelineName, pipelineID))
             .collect(toList());
+        
+        LOG.info(format("Total dependencies to examine: %d", allDependencies.size()));
+        
+        // Iteratively accept builds until no more can be accepted
+        // This handles diamond dependencies where we might need multiple passes
+        boolean changed = true;
+        int iteration = 0;
+        while (changed) {
+            iteration++;
+            changed = false;
+            LOG.debug(format("Chain membership iteration %d", iteration));
+            
+            for (SBuild dependency : allDependencies) {
+                // Skip if already accepted
+                if (acceptedBuilds.containsKey(dependency.getBuildId())) {
+                    continue;
+                }
+                
+                // Log trigger info for visibility
+                logTriggeredByInfo(dependency, "DEPENDENCY");
+                
+                // Check if this dependency was triggered by an accepted build
+                if (isTriggeredByAcceptedBuild(dependency, acceptedBuilds.keySet())) {
+                    LOG.info(format("Accepting build #%d '%s' into chain", dependency.getBuildId(), buildName(dependency)));
+                    acceptedBuilds.put(dependency.getBuildId(), dependency);
+                    
+                    // Update min/max times
+                    if (dependency.getStartDate().before(minStartTime)) {
+                        minStartTime = dependency.getStartDate();
+                    }
+                    if (dependency.getFinishDate() != null && dependency.getFinishDate().after(maxFinishTime)) {
+                        maxFinishTime = dependency.getFinishDate();
+                    }
+                    
+                    changed = true;
+                } else {
+                    LOG.debug(format("Build #%d '%s' not triggered by accepted build", dependency.getBuildId(), buildName(dependency)));
+                }
+            }
+        }
+        
+        LOG.info(format("Chain membership resolved after %d iterations", iteration));
+        
+        // Return accepted builds (excluding the pipeline build itself)
+        List<SBuild> chainMembers = acceptedBuilds.values().stream()
+            .filter(build -> build.getBuildId() != pipelineBuild.getBuildId())
+            .collect(toList());
+            
+        return new ChainMembership(chainMembers, minStartTime, maxFinishTime);
+    }
+    
+    /**
+     * Checks if a build was triggered by one of the accepted builds in the chain.
+     */
+    private boolean isTriggeredByAcceptedBuild(SBuild build, Set<Long> acceptedBuildIds) {
+        try {
+            jetbrains.buildServer.serverSide.TriggeredBy triggeredBy = build.getTriggeredBy();
+            if (triggeredBy == null) {
+                return false;
+            }
+            
+            Map<String, String> params = triggeredBy.getParameters();
+            
+            // Check if triggered as snapshot dependency
+            if (!"snapshotDependency".equals(params.get("type"))) {
+                return false;
+            }
+            
+            // Check if triggered by a build in the accepted set
+            String triggeringBuildId = params.get("buildId");
+            if (triggeringBuildId == null) {
+                return false;
+            }
+            
+            try {
+                long buildId = Long.parseLong(triggeringBuildId);
+                return acceptedBuildIds.contains(buildId);
+            } catch (NumberFormatException e) {
+                LOG.warn(format("Invalid buildId in trigger parameters: %s", triggeringBuildId));
+                return false;
+            }
+        } catch (Exception e) {
+            LOG.warn(format("Failed to check trigger for build %s: %s", build.getBuildId(), e.getMessage()), e);
+            return false;
+        }
+    }
+    
+    /**
+     * Container for chain membership information
+     */
+    private static class ChainMembership {
+        final List<SBuild> acceptedBuilds;
+        final Date minStartTime;
+        final Date maxFinishTime;
+        
+        ChainMembership(List<SBuild> acceptedBuilds, Date minStartTime, Date maxFinishTime) {
+            this.acceptedBuilds = acceptedBuilds;
+            this.minStartTime = minStartTime;
+            this.maxFinishTime = maxFinishTime;
+        }
     }
 
-    private boolean shouldBeIgnored(SBuild jobBuild, Date pipelineStart) {
+    private boolean shouldBeIgnored(SBuild jobBuild) {
         return jobBuild.isCompositeBuild() || // We ignore composite builds as they do not have any steps
             jobBuild.isPersonal() ||
-            jobBuild.getFinishDate() == null || // This can happen in case the build is canceled before it starts
-            // For partial retries, we ignore jobs started before the pipeline,
-            // as they are reused builds which were already sent by previous webhooks
-            jobBuild.getStartDate().before(pipelineStart);
+            jobBuild.getFinishDate() == null; // This can happen in case the build is canceled before it starts
     }
 
     private JobWebhook createJobWebhook(SBuild jobBuild, String pipelineName, String pipelineID) {
@@ -242,5 +368,34 @@ public class BuildChainProcessor {
     private String buildID(SBuild build) {
         // Server ID is included to avoid build ID conflicts on different TC instances within the same org
         return format("%s-%s", serverSettings.getServerUUID(), build.getBuildId());
+    }
+
+    /**
+     * Logs detailed information from TriggeredBy for debugging purposes.
+     */
+    private void logTriggeredByInfo(SBuild build, String buildType) {
+        try {
+            LOG.info(format("--- %s: Build #%d '%s' ---", buildType, build.getBuildId(), buildName(build)));
+            LOG.info(format("  Build ID: %s", buildID(build)));
+            LOG.info(format("  Is Composite: %s", build.isCompositeBuild()));
+            LOG.info(format("  Start Date: %s", build.getStartDate()));
+            LOG.info(format("  Finish Date: %s", build.getFinishDate()));
+            
+            jetbrains.buildServer.serverSide.TriggeredBy triggeredBy = build.getTriggeredBy();
+            if (triggeredBy != null) {
+                LOG.info("  TriggeredBy Information:");
+                LOG.info(format("    AsString: %s", triggeredBy.getAsString()));
+                LOG.info(format("    RawTriggeredBy: %s", triggeredBy.getRawTriggeredBy()));
+                LOG.info(format("    TriggeredDate: %s", triggeredBy.getTriggeredDate()));
+                LOG.info(format("    IsTriggeredByUser: %s", triggeredBy.isTriggeredByUser()));
+                LOG.info(format("    User: %s", triggeredBy.getUser() != null ? triggeredBy.getUser().getUsername() : "null"));
+                LOG.info(format("    TriggerId: %s", triggeredBy.getTriggerId()));
+                LOG.info(format("    Parameters: %s", triggeredBy.getParameters()));
+            } else {
+                LOG.warn("  TriggeredBy is null!");
+            }
+        } catch (Exception e) {
+            LOG.warn(format("Failed to log TriggeredBy info for build %s: %s", build.getBuildId(), e.getMessage()), e);
+        }
     }
 }

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainProcessor.java
@@ -215,10 +215,17 @@ public class BuildChainProcessor {
         
         LOG.info(format("Chain membership resolved after %d iterations", iteration));
         
-        // Return accepted builds (excluding the pipeline build itself)
-        List<SBuild> chainMembers = acceptedBuilds.values().stream()
-            .filter(build -> build.getBuildId() != pipelineBuild.getBuildId())
-            .collect(toList());
+        // Return all accepted builds (for composite head builds, exclude the head; for non-composite, include it)
+        List<SBuild> chainMembers;
+        if (pipelineBuild.isCompositeBuild()) {
+            // Composite builds: exclude the head build (it's just the pipeline frame)
+            chainMembers = acceptedBuilds.values().stream()
+                .filter(build -> build.getBuildId() != pipelineBuild.getBuildId())
+                .collect(toList());
+        } else {
+            // Non-composite builds: include the head build as a job
+            chainMembers = new ArrayList<>(acceptedBuilds.values());
+        }
             
         return new ChainMembership(chainMembers, minQueueTime, maxFinishTime);
     }

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapter.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapter.java
@@ -56,12 +56,12 @@ public class DatadogServerAdapter extends BuildServerAdapter {
             return;
         }
 
-        if (!isLastCompositeBuild(build)) {
+        if (!isProcessableBuild(build)) {
             LOG.info(format("Ignoring build with id '%s' and name '%s'", build.getBuildId(), buildName(build)));
             return;
         }
 
-        // At this point, we know it's the final composite build of the chain
+        // At this point, we know it's a build we should process
         SBuild pipelineBuild = buildsManager.findBuildInstanceById(build.getBuildId());
         if (pipelineBuild == null) {
             // This should not happen, but better to check for it anyway
@@ -72,9 +72,22 @@ public class DatadogServerAdapter extends BuildServerAdapter {
         buildChainProcessor.process(pipelineBuild);
     }
 
-    private boolean isLastCompositeBuild(SBuild build) {
-        return build.isCompositeBuild() &&
-            build.getBuildPromotion().getNumberOfDependedOnMe() == 0 &&
-            !build.isPersonal();
+    private boolean isProcessableBuild(SBuild build) {
+        // Personal builds are never processed
+        if (build.isPersonal()) {
+            return false;
+        }
+
+        // Must be the final build in the chain (no dependents)
+        if (build.getBuildPromotion().getNumberOfDependedOnMe() != 0) {
+            return false;
+        }
+
+        // If it's a non-composite build, reject if feature is not enabled.
+        if (!build.isCompositeBuild() && !projectHandler.isNonCompositeEnabled(build)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -28,6 +28,7 @@ public class ProjectHandler {
     protected static final String DATADOG_API_KEY_PARAM = "datadog.ci.api.key";
     protected static final String DATADOG_SITE_PARAM = "datadog.ci.site";
     protected static final String DATADOG_ENABLED_PARAM = "datadog.ci.enabled";
+    protected static final String DATADOG_ENABLE_NON_COMPOSITE_PARAM = "datadog.ci.enable.non-composite";
 
     private final ProjectManager projectManager;
 
@@ -58,6 +59,11 @@ public class ProjectHandler {
         }
 
         return isPluginEnabled;
+    }
+
+    public boolean isNonCompositeEnabled(SBuild build) {
+        String enabled = build.getParametersProvider().get(DATADOG_ENABLE_NON_COMPOSITE_PARAM);
+        return Boolean.parseBoolean(enabled);
     }
 
     @Nonnull

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainMembershipTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainMembershipTest.java
@@ -1,0 +1,334 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/)
+ * Copyright 2022-present Datadog, Inc.
+ */
+
+package jetbrains.buildServer.com.datadog.teamcity.plugin;
+
+import jetbrains.buildServer.com.datadog.teamcity.plugin.model.entities.PipelineWebhook;
+import jetbrains.buildServer.com.datadog.teamcity.plugin.model.entities.Webhook;
+import jetbrains.buildServer.messages.Status;
+import jetbrains.buildServer.serverSide.SBuildServer;
+import jetbrains.buildServer.serverSide.SRunningBuild;
+import jetbrains.buildServer.serverSide.ServerSettings;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+import static jetbrains.buildServer.com.datadog.teamcity.plugin.BuildUtils.toRFC3339;
+import static jetbrains.buildServer.com.datadog.teamcity.plugin.MockBuild.BuildType.JOB;
+import static jetbrains.buildServer.com.datadog.teamcity.plugin.MockBuild.BuildType.PIPELINE;
+import static jetbrains.buildServer.com.datadog.teamcity.plugin.TestUtils.DEFAULT_SERVER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the chain membership algorithm that determines which builds
+ * are part of a triggered build chain based on snapshot dependencies.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BuildChainMembershipTest {
+
+    @Mock
+    private SBuildServer buildServer;
+    
+    @Mock
+    private DatadogClient datadogClient;
+    
+    @Mock
+    private ProjectHandler projectHandler;
+    
+    @Mock
+    private GitInformationExtractor gitInformationExtractor;
+    
+    @Mock
+    private ServerSettings serverSettings;
+    
+    private BuildChainProcessor buildChainProcessor;
+
+    @Before
+    public void setUp() {
+        when(serverSettings.getServerUUID()).thenReturn(DEFAULT_SERVER_ID);
+        when(buildServer.getRootUrl()).thenReturn("http://localhost:8111");
+        
+        buildChainProcessor = new BuildChainProcessor(
+            buildServer,
+            datadogClient,
+            projectHandler,
+            gitInformationExtractor,
+            serverSettings
+        );
+    }
+
+    @Test
+    public void shouldAcceptDependencyTriggeredByPipeline() {
+        // Given: A pipeline build with one dependency triggered by snapshot dependency
+        long pipelineId = 100L;
+        long jobId = 99L;
+        
+        SRunningBuild job = new MockBuild.Builder(jobId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(pipelineId)
+            .build();
+        
+        SRunningBuild pipeline = new MockBuild.Builder(pipelineId, PIPELINE)
+            .withStatus(Status.NORMAL)
+            .isTriggeredByUser()
+            .withAllDependencies(Arrays.asList(job))
+            .build();
+        
+        // When: Processing the pipeline
+        List<Webhook> webhooks = buildChainProcessor.createWebhooks(pipeline);
+        
+        // Then: Should have 1 pipeline webhook + 1 job webhook
+        assertThat(webhooks).hasSize(2);
+        assertThat(webhooks.get(0)).isInstanceOf(PipelineWebhook.class);
+        assertThat(webhooks.get(1)).isNotInstanceOf(PipelineWebhook.class); // JobWebhook
+    }
+
+    @Test
+    public void shouldRejectDependencyTriggeredBySchedule() {
+        // Given: A pipeline with a re-used dependency from a previous scheduled run
+        long pipelineId = 100L;
+        long reusedJobId = 50L; // Old build from earlier
+        
+        SRunningBuild reusedJob = new MockBuild.Builder(reusedJobId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySchedule() // Not triggered by this pipeline
+            .withStartDate(hoursAgo(8)) // Started 8 hours ago
+            .withEndDate(hoursAgo(8))
+            .build();
+        
+        SRunningBuild pipeline = new MockBuild.Builder(pipelineId, PIPELINE)
+            .withStatus(Status.NORMAL)
+            .isTriggeredByUser()
+            .withStartDate(minutesAgo(5))
+            .withEndDate(minutesAgo(2))
+            .withAllDependencies(Arrays.asList(reusedJob))
+            .build();
+        
+        // When: Processing the pipeline
+        List<Webhook> webhooks = buildChainProcessor.createWebhooks(pipeline);
+        
+        // Then: Should only have 1 pipeline webhook (re-used job excluded)
+        assertThat(webhooks).hasSize(1);
+        assertThat(webhooks.get(0)).isInstanceOf(PipelineWebhook.class);
+    }
+
+    @Test
+    public void shouldHandleDiamondDependencyGraph() {
+        // Given: Diamond dependency graph
+        //        A (pipeline)
+        //       / \
+        //      B   C
+        //       \ /
+        //        D
+        long pipelineId = 100L;
+        long jobBId = 99L;
+        long jobCId = 98L;
+        long jobDId = 97L;
+        
+        SRunningBuild jobD = new MockBuild.Builder(jobDId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(jobBId) // Triggered by B
+            .build();
+        
+        SRunningBuild jobB = new MockBuild.Builder(jobBId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(pipelineId)
+            .withAllDependencies(Arrays.asList(jobD))
+            .build();
+        
+        SRunningBuild jobC = new MockBuild.Builder(jobCId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(pipelineId)
+            .withAllDependencies(Arrays.asList(jobD))
+            .build();
+        
+        SRunningBuild pipeline = new MockBuild.Builder(pipelineId, PIPELINE)
+            .withStatus(Status.NORMAL)
+            .isTriggeredByUser()
+            .withAllDependencies(Arrays.asList(jobB, jobC, jobD))
+            .build();
+        
+        // When: Processing the pipeline
+        List<Webhook> webhooks = buildChainProcessor.createWebhooks(pipeline);
+        
+        // Then: Should have 1 pipeline + 3 job webhooks (B, C, D all accepted)
+        assertThat(webhooks).hasSize(4);
+        assertThat(webhooks.get(0)).isInstanceOf(PipelineWebhook.class);
+    }
+
+    @Test
+    public void shouldComputeWholeChainTiming() {
+        // Given: A pipeline with dependencies that start before and end after the pipeline
+        long pipelineId = 100L;
+        long jobId = 99L;
+        
+        Date jobStartTime = hoursAgo(2);
+        Date jobEndTime = minutesAgo(5); // Job finishes AFTER pipeline (pipeline ends at 28 min ago)
+        Date pipelineStartTime = minutesAgo(30);
+        Date pipelineEndTime = minutesAgo(28);
+        
+        SRunningBuild job = new MockBuild.Builder(jobId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(pipelineId)
+            .withStartDate(jobStartTime)
+            .withEndDate(jobEndTime)
+            .withQueueDate(hoursAgo(3))
+            .build();
+        
+        SRunningBuild pipeline = new MockBuild.Builder(pipelineId, PIPELINE)
+            .withStatus(Status.NORMAL)
+            .isTriggeredByUser()
+            .withStartDate(pipelineStartTime)
+            .withEndDate(pipelineEndTime)
+            .withAllDependencies(Arrays.asList(job))
+            .build();
+        
+        // When
+        List<Webhook> webhooks = buildChainProcessor.createWebhooks(pipeline);
+        
+        // Then: Pipeline webhook should span from job start to job end
+        assertThat(webhooks).hasSize(2);
+        Webhook pipelineWebhook = webhooks.get(0);
+        String webhookStr = pipelineWebhook.toString();
+        assertThat(webhookStr).contains("start='" + toRFC3339(jobStartTime) + "'");
+        assertThat(webhookStr).contains("end='" + toRFC3339(jobEndTime) + "'");
+    }
+
+    @Test
+    public void shouldHandleMultiLevelDependencies() {
+        // Given: Three-level dependency chain A -> B -> C
+        long pipelineId = 100L;
+        long jobBId = 99L;
+        long jobCId = 98L;
+        
+        SRunningBuild jobC = new MockBuild.Builder(jobCId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(jobBId) // Triggered by B
+            .build();
+        
+        SRunningBuild jobB = new MockBuild.Builder(jobBId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(pipelineId) // Triggered by pipeline
+            .withAllDependencies(Arrays.asList(jobC))
+            .build();
+        
+        SRunningBuild pipeline = new MockBuild.Builder(pipelineId, PIPELINE)
+            .withStatus(Status.NORMAL)
+            .isTriggeredByUser()
+            .withAllDependencies(Arrays.asList(jobB, jobC))
+            .build();
+        
+        // When: Processing the pipeline
+        List<Webhook> webhooks = buildChainProcessor.createWebhooks(pipeline);
+        
+        // Then: Should accept all three levels (pipeline + B + C)
+        assertThat(webhooks).hasSize(3);
+    }
+
+    @Test
+    public void shouldExcludePersonalBuilds() {
+        // Given: A pipeline with a personal build dependency
+        long pipelineId = 100L;
+        long personalJobId = 99L;
+        
+        SRunningBuild personalJob = new MockBuild.Builder(personalJobId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(pipelineId)
+            .isPersonal() // Personal builds should be excluded
+            .build();
+        
+        SRunningBuild pipeline = new MockBuild.Builder(pipelineId, PIPELINE)
+            .withStatus(Status.NORMAL)
+            .isTriggeredByUser()
+            .withAllDependencies(Arrays.asList(personalJob))
+            .build();
+        
+        // When: Processing the pipeline
+        List<Webhook> webhooks = buildChainProcessor.createWebhooks(pipeline);
+        
+        // Then: Should only have pipeline webhook (personal job excluded)
+        assertThat(webhooks).hasSize(1);
+        assertThat(webhooks.get(0)).isInstanceOf(PipelineWebhook.class);
+    }
+
+    @Test
+    public void shouldExcludeBuildsWithoutFinishDate() {
+        // Given: A pipeline with a dependency that was canceled before it started
+        long pipelineId = 100L;
+        long canceledJobId = 99L;
+        
+        SRunningBuild canceledJob = new MockBuild.Builder(canceledJobId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(pipelineId)
+            .withEndDate(null) // No finish date
+            .build();
+        
+        SRunningBuild pipeline = new MockBuild.Builder(pipelineId, PIPELINE)
+            .withStatus(Status.NORMAL)
+            .isTriggeredByUser()
+            .withAllDependencies(Arrays.asList(canceledJob))
+            .build();
+        
+        // When: Processing the pipeline
+        List<Webhook> webhooks = buildChainProcessor.createWebhooks(pipeline);
+        
+        // Then: Should only have pipeline webhook (canceled job excluded)
+        assertThat(webhooks).hasSize(1);
+        assertThat(webhooks.get(0)).isInstanceOf(PipelineWebhook.class);
+    }
+
+    @Test
+    public void shouldHandleMixedAcceptedAndRejectedDependencies() {
+        // Given: A pipeline with both accepted and rejected dependencies
+        long pipelineId = 100L;
+        long acceptedJobId = 99L;
+        long reusedJobId = 50L;
+        
+        SRunningBuild acceptedJob = new MockBuild.Builder(acceptedJobId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySnapshotDependency(pipelineId)
+            .build();
+        
+        SRunningBuild reusedJob = new MockBuild.Builder(reusedJobId, JOB)
+            .withStatus(Status.NORMAL)
+            .isTriggeredBySchedule() // From previous run
+            .build();
+        
+        SRunningBuild pipeline = new MockBuild.Builder(pipelineId, PIPELINE)
+            .withStatus(Status.NORMAL)
+            .isTriggeredByUser()
+            .withAllDependencies(Arrays.asList(acceptedJob, reusedJob))
+            .build();
+        
+        // When: Processing the pipeline
+        List<Webhook> webhooks = buildChainProcessor.createWebhooks(pipeline);
+        
+        // Then: Should have 1 pipeline + 1 accepted job (reused job excluded)
+        assertThat(webhooks).hasSize(2);
+    }
+
+    // Helper methods for date manipulation
+    private Date hoursAgo(int hours) {
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.HOUR, -hours);
+        return cal.getTime();
+    }
+
+    private Date minutesAgo(int minutes) {
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.MINUTE, -minutes);
+        return cal.getTime();
+    }
+}

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainMembershipTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/BuildChainMembershipTest.java
@@ -174,6 +174,7 @@ public class BuildChainMembershipTest {
         long pipelineId = 100L;
         long jobId = 99L;
         
+        Date jobQueueTime = hoursAgo(3);
         Date jobStartTime = hoursAgo(2);
         Date jobEndTime = minutesAgo(5); // Job finishes AFTER pipeline (pipeline ends at 28 min ago)
         Date pipelineStartTime = minutesAgo(30);
@@ -184,7 +185,7 @@ public class BuildChainMembershipTest {
             .isTriggeredBySnapshotDependency(pipelineId)
             .withStartDate(jobStartTime)
             .withEndDate(jobEndTime)
-            .withQueueDate(hoursAgo(3))
+            .withQueueDate(jobQueueTime)
             .build();
         
         SRunningBuild pipeline = new MockBuild.Builder(pipelineId, PIPELINE)
@@ -192,17 +193,18 @@ public class BuildChainMembershipTest {
             .isTriggeredByUser()
             .withStartDate(pipelineStartTime)
             .withEndDate(pipelineEndTime)
+            .withQueueDate(pipelineStartTime)  // Pipeline queued when it started
             .withAllDependencies(Arrays.asList(job))
             .build();
         
         // When
         List<Webhook> webhooks = buildChainProcessor.createWebhooks(pipeline);
         
-        // Then: Pipeline webhook should span from job start to job end
+        // Then: Pipeline webhook should span from job queue time to job end
         assertThat(webhooks).hasSize(2);
         Webhook pipelineWebhook = webhooks.get(0);
         String webhookStr = pipelineWebhook.toString();
-        assertThat(webhookStr).contains("start='" + toRFC3339(jobStartTime) + "'");
+        assertThat(webhookStr).contains("start='" + toRFC3339(jobQueueTime) + "'");  // Queue time, not start time
         assertThat(webhookStr).contains("end='" + toRFC3339(jobEndTime) + "'");
     }
 

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
@@ -313,9 +313,11 @@ public class DatadogServerAdapterProcessingTest {
         Date firstJobStart = new Date(1000);
         Date pipelineStart = new Date(5000);
         SRunningBuild firstJobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(100)  // Old job from previous run (triggered by previous pipeline ID 100)
             .withStartDate(firstJobStart)
             .build();
         SRunningBuild secondJobBuild = new MockBuild.Builder(2, JOB)
+            .isTriggeredBySnapshotDependency(3)
             .withStartDate(pipelineStart)
             .withDependencies(singletonList(firstJobBuild))
             .build();

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
@@ -820,4 +820,118 @@ public class DatadogServerAdapterProcessingTest {
         List<Webhook> webhooksSent = webhooksCaptor.getValue();
         assertThat(webhooksSent).hasSize(2).hasSameElementsAs(expectedWebhooks);
     }
+
+    @Test
+    public void shouldProcessNonCompositeBuildWhenFeatureEnabled() {
+        // Setup: Non-composite job with feature enabled
+        SRunningBuild nonCompositeBuild = new MockBuild.Builder(1, JOB)
+            .withNumOfDependents(0)  // Must be final build in chain
+            .build();
+        when(buildsManagerMock.findBuildInstanceById(1)).thenReturn(nonCompositeBuild);
+        when(projectHandlerMock.isNonCompositeEnabled(nonCompositeBuild)).thenReturn(true);
+
+        // When
+        datadogServerAdapter.buildFinished(nonCompositeBuild);
+
+        // Then
+        verify(datadogClientMock, times(1))
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+
+        // Should create 1 pipeline webhook and 1 job webhook for the non-composite build itself
+        PipelineWebhook expectedPipelineWebhook = new PipelineWebhook(
+            DEFAULT_NAME,
+            defaultUrl(nonCompositeBuild),
+            toRFC3339(DEFAULT_QUEUE_DATE),  // Pipeline start uses job's queue time
+            toRFC3339(DEFAULT_END_DATE),
+            "serverID-1",
+            "1",
+            NO_PARTIAL_RETRY,
+            PipelineStatus.SUCCESS);
+
+        JobWebhook expectedJobWebhook = new JobWebhook(
+            DEFAULT_NAME,
+            defaultUrl(nonCompositeBuild),
+            toRFC3339(DEFAULT_START_DATE),  // Job start time
+            toRFC3339(DEFAULT_END_DATE),
+            "serverID-1",
+            DEFAULT_NAME,
+            "serverID-1",
+            JobStatus.SUCCESS,
+            DEFAULT_QUEUE_TIME);  // Queue time = start - queue = 3000 - 2000 = 1000ms
+
+        List<Webhook> webhooksSent = webhooksCaptor.getValue();
+        assertThat(webhooksSent).hasSize(2).containsExactlyInAnyOrder(expectedPipelineWebhook, expectedJobWebhook);
+    }
+
+    @Test
+    public void shouldIgnoreNonCompositeBuildWhenFeatureDisabled() {
+        // Setup: Non-composite job with feature disabled (default)
+        SRunningBuild nonCompositeBuild = new MockBuild.Builder(1, JOB)
+            .withNumOfDependents(0)
+            .build();
+        when(projectHandlerMock.isNonCompositeEnabled(nonCompositeBuild)).thenReturn(false);
+
+        // When
+        datadogServerAdapter.buildFinished(nonCompositeBuild);
+
+        // Then: Should not process the build
+        verifyZeroInteractions(datadogClientMock, buildsManagerMock);
+    }
+
+    @Test
+    public void shouldProcessNonCompositeBuildWithDependencies() {
+        // Setup: [dependency job -> non-composite job (feature enabled)]
+        SRunningBuild dependencyBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(2)
+            .build();
+        SRunningBuild nonCompositeBuild = new MockBuild.Builder(2, JOB)
+            .withNumOfDependents(0)  // Must be final build in chain
+            .withAllDependencies(singletonList(dependencyBuild))
+            .build();
+
+        when(buildsManagerMock.findBuildInstanceById(2)).thenReturn(nonCompositeBuild);
+        when(projectHandlerMock.isNonCompositeEnabled(nonCompositeBuild)).thenReturn(true);
+
+        // When
+        datadogServerAdapter.buildFinished(nonCompositeBuild);
+
+        // Then
+        verify(datadogClientMock, times(1))
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+
+        // Should create 1 pipeline webhook and 2 job webhooks (the non-composite build + its dependency)
+        List<Webhook> expectedWebhooks = Arrays.asList(
+            new PipelineWebhook(
+                DEFAULT_NAME,
+                defaultUrl(nonCompositeBuild),
+                toRFC3339(DEFAULT_QUEUE_DATE),
+                toRFC3339(DEFAULT_END_DATE),
+                "serverID-2",
+                "2",
+                NO_PARTIAL_RETRY,
+                PipelineStatus.SUCCESS),
+            new JobWebhook(
+                DEFAULT_NAME,
+                defaultUrl(dependencyBuild),
+                toRFC3339(DEFAULT_START_DATE),
+                toRFC3339(DEFAULT_END_DATE),
+                "serverID-2",
+                DEFAULT_NAME,
+                "serverID-1",
+                JobStatus.SUCCESS,
+                DEFAULT_QUEUE_TIME),
+            new JobWebhook(
+                DEFAULT_NAME,
+                defaultUrl(nonCompositeBuild),
+                toRFC3339(DEFAULT_START_DATE),
+                toRFC3339(DEFAULT_END_DATE),
+                "serverID-2",
+                DEFAULT_NAME,
+                "serverID-2",
+                JobStatus.SUCCESS,
+                DEFAULT_QUEUE_TIME));
+
+        List<Webhook> webhooksSent = webhooksCaptor.getValue();
+        assertThat(webhooksSent).hasSize(3).hasSameElementsAs(expectedWebhooks);
+    }
 }

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
@@ -39,6 +39,7 @@ import static jetbrains.buildServer.com.datadog.teamcity.plugin.MockBuild.BuildT
 import static jetbrains.buildServer.com.datadog.teamcity.plugin.MockBuild.BuildType.PIPELINE;
 import static jetbrains.buildServer.com.datadog.teamcity.plugin.TestUtils.DEFAULT_END_DATE;
 import static jetbrains.buildServer.com.datadog.teamcity.plugin.TestUtils.DEFAULT_NAME;
+import static jetbrains.buildServer.com.datadog.teamcity.plugin.TestUtils.DEFAULT_QUEUE_DATE;
 import static jetbrains.buildServer.com.datadog.teamcity.plugin.TestUtils.DEFAULT_QUEUE_TIME;
 import static jetbrains.buildServer.com.datadog.teamcity.plugin.TestUtils.DEFAULT_SERVER_ID;
 import static jetbrains.buildServer.com.datadog.teamcity.plugin.TestUtils.DEFAULT_START_DATE;
@@ -225,7 +226,7 @@ public class DatadogServerAdapterProcessingTest {
             new PipelineWebhook(
                 DEFAULT_NAME,
                 defaultUrl(pipelineBuild),
-                toRFC3339(DEFAULT_START_DATE),
+                toRFC3339(DEFAULT_QUEUE_DATE),
                 toRFC3339(DEFAULT_END_DATE),
                 "serverID-2",
                 "2",
@@ -285,7 +286,7 @@ public class DatadogServerAdapterProcessingTest {
             new PipelineWebhook(
                 DEFAULT_NAME,
                 defaultUrl(pipelineBuild),
-                toRFC3339(DEFAULT_START_DATE),
+                toRFC3339(DEFAULT_QUEUE_DATE),
                 toRFC3339(DEFAULT_END_DATE),
                 "serverID-3",
                 "3",
@@ -318,6 +319,7 @@ public class DatadogServerAdapterProcessingTest {
             .build();
         SRunningBuild secondJobBuild = new MockBuild.Builder(2, JOB)
             .isTriggeredBySnapshotDependency(3)
+            .withQueueDate(pipelineStart)
             .withStartDate(pipelineStart)
             .withDependencies(singletonList(firstJobBuild))
             .build();
@@ -345,7 +347,7 @@ public class DatadogServerAdapterProcessingTest {
             DEFAULT_NAME,
             "serverID-2",
             JobStatus.SUCCESS,
-            3000);
+            0);
         secondJobWebhook.setDependenciesIds(singletonList("serverID-1"));
 
         List<Webhook> expectedWebhooks = Arrays.asList(
@@ -392,7 +394,7 @@ public class DatadogServerAdapterProcessingTest {
             new PipelineWebhook(
                 DEFAULT_NAME,
                 defaultUrl(pipelineBuild),
-                toRFC3339(DEFAULT_START_DATE),
+                toRFC3339(DEFAULT_QUEUE_DATE),
                 toRFC3339(DEFAULT_END_DATE),
                 "serverID-3",
                 "3",
@@ -441,7 +443,7 @@ public class DatadogServerAdapterProcessingTest {
             new PipelineWebhook(
                 DEFAULT_NAME,
                 defaultUrl(pipelineBuild),
-                toRFC3339(DEFAULT_START_DATE),
+                toRFC3339(DEFAULT_QUEUE_DATE),
                 toRFC3339(DEFAULT_END_DATE),
                 "serverID-3",
                 "3",
@@ -469,6 +471,7 @@ public class DatadogServerAdapterProcessingTest {
         Date pipelineStart = new Date(5000);
         SRunningBuild jobBuild = new MockBuild.Builder(1, JOB)
             .isTriggeredBySnapshotDependency(2)
+            .withQueueDate(jobStart)
             .withStartDate(jobStart)
             .build();
         SRunningBuild pipelineBuild = new MockBuild.Builder(2, PIPELINE)
@@ -504,7 +507,57 @@ public class DatadogServerAdapterProcessingTest {
                 DEFAULT_NAME,
                 "serverID-1",
                 JobStatus.SUCCESS,
-                2000));  // Queue time = jobStart(4000) - DEFAULT_QUEUE_DATE(2000) = 2000ms
+                0));
+
+        List<Webhook> webhooksSent = webhooksCaptor.getValue();
+        assertThat(webhooksSent).hasSize(2).hasSameElementsAs(expectedWebhooks);
+    }
+
+    @Test
+    public void shouldUsePipelineTimingFromJobQueueTime() {
+        // Setup: [job -> pipeline]. Job was queued earlier than it started - pipeline timing should include queue time
+        Date jobQueueTime = new Date(1000);
+        Date jobStartTime = new Date(4000);
+        Date pipelineStart = new Date(5000);
+        SRunningBuild jobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(2)
+            .withQueueDate(jobQueueTime)
+            .withStartDate(jobStartTime)
+            .build();
+        SRunningBuild pipelineBuild = new MockBuild.Builder(2, PIPELINE)
+            .withStartDate(pipelineStart)
+            .withAllDependencies(singletonList(jobBuild))
+            .build();
+
+        when(buildsManagerMock.findBuildInstanceById(2)).thenReturn(pipelineBuild);
+
+        // When
+        datadogServerAdapter.buildFinished(pipelineBuild);
+
+        // Then
+        verify(datadogClientMock, times(1))
+            .sendWebhooksAsync(webhooksCaptor.capture(), eq(TEST_API_KEY), eq(TEST_DD_SITE));
+
+        List<Webhook> expectedWebhooks = Arrays.asList(
+            new PipelineWebhook(
+                DEFAULT_NAME,
+                defaultUrl(pipelineBuild),
+                toRFC3339(jobQueueTime),
+                toRFC3339(DEFAULT_END_DATE),
+                "serverID-2",
+                "2",
+                NO_PARTIAL_RETRY,
+                PipelineStatus.SUCCESS),
+            new JobWebhook(
+                DEFAULT_NAME,
+                defaultUrl(jobBuild),
+                toRFC3339(jobStartTime),  // Job webhook uses actual start time
+                toRFC3339(DEFAULT_END_DATE),
+                "serverID-2",
+                DEFAULT_NAME,
+                "serverID-1",
+                JobStatus.SUCCESS,
+                3000));  // Queue time = jobStartTime(4000) - jobQueueTime(1000) = 3000ms
 
         List<Webhook> webhooksSent = webhooksCaptor.getValue();
         assertThat(webhooksSent).hasSize(2).hasSameElementsAs(expectedWebhooks);
@@ -549,7 +602,7 @@ public class DatadogServerAdapterProcessingTest {
             new PipelineWebhook(
                 DEFAULT_NAME,
                 defaultUrl(pipelineBuild),
-                toRFC3339(DEFAULT_START_DATE),
+                toRFC3339(DEFAULT_QUEUE_DATE),
                 toRFC3339(DEFAULT_END_DATE),
                 "serverID-2",
                 "2",
@@ -584,7 +637,7 @@ public class DatadogServerAdapterProcessingTest {
         PipelineWebhook expectedPipelineWebhook = new PipelineWebhook(
             DEFAULT_NAME,
             defaultUrl(pipelineBuild),
-            toRFC3339(DEFAULT_START_DATE),
+            toRFC3339(DEFAULT_QUEUE_DATE),
             toRFC3339(DEFAULT_END_DATE),
             "serverID-2",
             "2",
@@ -699,7 +752,7 @@ public class DatadogServerAdapterProcessingTest {
                 new PipelineWebhook(
                         DEFAULT_NAME,
                         emptyUrl,
-                        toRFC3339(DEFAULT_START_DATE),
+                        toRFC3339(DEFAULT_QUEUE_DATE),
                         toRFC3339(DEFAULT_END_DATE),
                         "serverID-2",
                         "2",
@@ -747,7 +800,7 @@ public class DatadogServerAdapterProcessingTest {
                 new PipelineWebhook(
                         DEFAULT_NAME,
                         nonDefaultUrl(pipelineBuild),
-                        toRFC3339(DEFAULT_START_DATE),
+                        toRFC3339(DEFAULT_QUEUE_DATE),
                         toRFC3339(DEFAULT_END_DATE),
                         "serverID-2",
                         "2",

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
@@ -464,10 +464,11 @@ public class DatadogServerAdapterProcessingTest {
 
     @Test
     public void shouldSendWebhooksAccountingForStartOffset() {
-        // Setup: [job -> pipeline]. The job started before the pipeline, but it is within the offset of 3s
+        // Setup: [job -> pipeline]. The job started before the pipeline - pipeline timing should expand to include job
         Date jobStart = new Date(4000);
         Date pipelineStart = new Date(5000);
         SRunningBuild jobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(2)
             .withStartDate(jobStart)
             .build();
         SRunningBuild pipelineBuild = new MockBuild.Builder(2, PIPELINE)
@@ -488,7 +489,7 @@ public class DatadogServerAdapterProcessingTest {
             new PipelineWebhook(
                 DEFAULT_NAME,
                 defaultUrl(pipelineBuild),
-                toRFC3339(pipelineStart),
+                toRFC3339(jobStart),  // Pipeline start should be earliest (job start)
                 toRFC3339(DEFAULT_END_DATE),
                 "serverID-2",
                 "2",
@@ -503,7 +504,7 @@ public class DatadogServerAdapterProcessingTest {
                 DEFAULT_NAME,
                 "serverID-1",
                 JobStatus.SUCCESS,
-                2000));
+                2000));  // Queue time = jobStart(4000) - DEFAULT_QUEUE_DATE(2000) = 2000ms
 
         List<Webhook> webhooksSent = webhooksCaptor.getValue();
         assertThat(webhooksSent).hasSize(2).hasSameElementsAs(expectedWebhooks);

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/DatadogServerAdapterProcessingTest.java
@@ -205,7 +205,9 @@ public class DatadogServerAdapterProcessingTest {
     @Test
     public void shouldProcessPipelineBuildWithOneDependency() {
         // Setup: [job -> pipeline]
-        SRunningBuild jobBuild = new MockBuild.Builder(1, JOB).build();
+        SRunningBuild jobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(2)
+            .build();
         SRunningBuild pipelineBuild = new MockBuild.Builder(2, PIPELINE)
             .withAllDependencies(singletonList(jobBuild))
             .build();
@@ -247,8 +249,11 @@ public class DatadogServerAdapterProcessingTest {
     @Test
     public void shouldProcessPipelineBuildWithMultipleDependencies() {
         // Setup: [firstJob -> secondJob -> pipeline]
-        SRunningBuild firstJobBuild = new MockBuild.Builder(1, JOB).build();
+        SRunningBuild firstJobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(3)
+            .build();
         SRunningBuild secondJobBuild = new MockBuild.Builder(2, JOB)
+            .isTriggeredBySnapshotDependency(3)
             .withDependencies(singletonList(firstJobBuild))
             .build();
         SRunningBuild pipelineBuild = new MockBuild.Builder(3, PIPELINE)
@@ -360,7 +365,9 @@ public class DatadogServerAdapterProcessingTest {
     @Test
     public void shouldNotSendWebhooksForMiddleCompositeBuilds() {
         // Setup: [firstJob -> secondJob (composite) -> pipeline]
-        SRunningBuild firstJobBuild = new MockBuild.Builder(1, JOB).build();
+        SRunningBuild firstJobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(3)
+            .build();
         SRunningBuild secondJobBuild = new MockBuild.Builder(2, JOB)
             .withAllDependencies(singletonList(firstJobBuild))
             .isComposite()
@@ -407,7 +414,9 @@ public class DatadogServerAdapterProcessingTest {
     @Test
     public void shouldNotSendWebhooksForPersonalBuilds() {
         // Setup: [firstJob -> secondJob (personal) -> pipeline]
-        SRunningBuild firstJobBuild = new MockBuild.Builder(1, JOB).build();
+        SRunningBuild firstJobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(3)
+            .build();
         SRunningBuild secondJobBuild = new MockBuild.Builder(2, JOB)
             .withAllDependencies(singletonList(firstJobBuild))
             .isPersonal()
@@ -502,6 +511,7 @@ public class DatadogServerAdapterProcessingTest {
     public void shouldSendJobWebhookWithAdditionalInformation() {
         // Setup: [job -> pipeline]
          SRunningBuild jobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(2)
             .addNodeInformation()
             .withFailureReason(TC_FAILED_TESTS_TYPE)
             .build();
@@ -552,6 +562,7 @@ public class DatadogServerAdapterProcessingTest {
     public void shouldSendWebhooksWithGitInformation() {
         // Setup: [job -> pipeline]
         SRunningBuild jobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(2)
             .build();
         SRunningBuild pipelineBuild = new MockBuild.Builder(2, PIPELINE)
             .withAllDependencies(singletonList(jobBuild))
@@ -662,7 +673,9 @@ public class DatadogServerAdapterProcessingTest {
         when(buildServerMock.getRootUrl()).thenReturn("invalid-protocol://hostname");
 
         // Setup: [job -> pipeline]
-        SRunningBuild jobBuild = new MockBuild.Builder(1, JOB).build();
+        SRunningBuild jobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(2)
+            .build();
         SRunningBuild pipelineBuild = new MockBuild.Builder(2, PIPELINE)
                 .withAllDependencies(singletonList(jobBuild))
                 .build();
@@ -707,7 +720,9 @@ public class DatadogServerAdapterProcessingTest {
     @Test
     public void shouldGenerateValidURLs() {
         // Setup: [job -> pipeline]
-        SRunningBuild jobBuild = new MockBuild.Builder(1, JOB).build();
+        SRunningBuild jobBuild = new MockBuild.Builder(1, JOB)
+            .isTriggeredBySnapshotDependency(2)
+            .build();
         SRunningBuild pipelineBuild = new MockBuild.Builder(2, PIPELINE)
                 .withAllDependencies(singletonList(jobBuild))
                 .build();

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/MockBuild.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/MockBuild.java
@@ -111,6 +111,7 @@ public class MockBuild {
         private Date startDate = DEFAULT_START_DATE;
         private Date endDate = DEFAULT_END_DATE;
         private Date queueDate = DEFAULT_QUEUE_DATE;
+        private boolean queueDateExplicitlySet = false;  // Track if queue date was explicitly set
         private Branch branchMock;
         private List<String> tags = new ArrayList<>();
         private final List<SVcsModification> changesListMock = new ArrayList<>();
@@ -204,6 +205,7 @@ public class MockBuild {
 
         public Builder withQueueDate(Date queueDate) {
             this.queueDate = queueDate;
+            this.queueDateExplicitlySet = true;
             return this;
         }
 
@@ -289,6 +291,17 @@ public class MockBuild {
         }
 
         public SRunningBuild build() {
+            // For PIPELINE (composite) builds, queue date should equal start date unless explicitly set
+            // Pipelines don't wait in a queue - they start immediately when triggered
+            if (this.isComposite && !this.queueDateExplicitlySet) {
+                this.queueDate = this.startDate;
+            }
+            // For JOB builds, if queue date wasn't explicitly set, ensure it's never later than start date
+            // Use min(DEFAULT_QUEUE_DATE, startDate) to preserve default queue time for standard cases
+            // while ensuring early-starting jobs have queue time = 0
+            else if (!this.queueDateExplicitlySet && this.startDate != DEFAULT_START_DATE) {
+                this.queueDate = this.startDate.before(DEFAULT_QUEUE_DATE) ? this.startDate : DEFAULT_QUEUE_DATE;
+            }
             return fromBuilder(this);
         }
     }

--- a/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/MockBuild.java
+++ b/datadog-ci-integration-server/src/test/java/jetbrains/buildServer/com/datadog/teamcity/plugin/MockBuild.java
@@ -27,7 +27,9 @@ import jetbrains.buildServer.vcs.impl.VcsModificationEx;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
 import static jetbrains.buildServer.com.datadog.teamcity.plugin.BuildChainProcessor.CHECKOUT_DIR_PROPERTY;
@@ -147,6 +149,31 @@ public class MockBuild {
 
         public Builder isTriggeredByRetry() {
             when(triggeredBy.getParameters()).thenReturn(Collections.singletonMap("type", "retry"));
+            return this;
+        }
+
+        public Builder isTriggeredBySnapshotDependency(long triggeringBuildId) {
+            Map<String, String> params = new HashMap<>();
+            params.put("type", "snapshotDependency");
+            params.put("buildId", String.valueOf(triggeringBuildId));
+            params.put("userId", "1");
+            when(triggeredBy.getParameters()).thenReturn(params);
+            return this;
+        }
+
+        public Builder isTriggeredBySchedule() {
+            Map<String, String> params = new HashMap<>();
+            params.put("type", "schedule");
+            params.put("triggerId", "TRIGGER_1");
+            when(triggeredBy.getParameters()).thenReturn(params);
+            return this;
+        }
+
+        public Builder isTriggeredByUser() {
+            Map<String, String> params = new HashMap<>();
+            params.put("type", "user");
+            params.put("userId", "1");
+            when(triggeredBy.getParameters()).thenReturn(params);
             return this;
         }
 


### PR DESCRIPTION
What does this PR do?
---------------------

- Optionally enable build chains not ending in a composite build.

The need for a terminating composite build for a pipeiline is somewhat artificial.  The current implementation
uses this to determine the total timespan of the pipeline.

This PR changes how requirements are traversed, eliminating the need for a final composite build:

- snapshot dependencies are traversed.
- the triggering build is examined.
- the dependency is accepted if the triggering build is part of the accepted build chain.
- the pipeline parameters (start and end, etc) are determined from the total of the found builds.
- the pipeline id is the id of the triggering build job.  Pipelines and jobs have different unique id namespaces.

This eliminates the need to filter the chain based on time range, and automatically excludes builds that are re-used
due to retries.

This feature can be enabled, on a build-by-build basis or globally, using the `datadog.ci.enable.non-composite`.

### Review checklist

- [x] I have added unit tests if applicable
- [x] (Only for critical changes) I have tested that the changes work in a TeamCity server
