### PR TITLE
Add support for job-level parameter overrides

### DIFF
--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -68,7 +68,8 @@ public class ProjectHandler {
 
     private String getApiKey(SBuild build) {
         // API key is a password parameter and needs ValueResolver to get the unscrambled value
-        // ValueResolver resolves from the project hierarchy, which includes job-level overrides
+        // ValueResolver resolves from the project hierarchy, job level overrides are
+        // not possible.
         ProjectEx project = getProject(build);
         String apiKeyReference = String.format("%%%s%%", DATADOG_API_KEY_PARAM);
         ValueResolver resolver = project.getValueResolver();
@@ -78,7 +79,7 @@ public class ProjectHandler {
                     format("Could not find required property '%s' for build %s",
                             DATADOG_API_KEY_PARAM, build.getBuildId()));
         }
-        
+
         return resolved.getResult();
     }
 

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -8,8 +8,6 @@
 package jetbrains.buildServer.com.datadog.teamcity.plugin;
 
 import com.intellij.openapi.diagnostic.Logger;
-import jetbrains.buildServer.parameters.ProcessingResult;
-import jetbrains.buildServer.parameters.ValueResolver;
 import jetbrains.buildServer.serverSide.ProjectManager;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.impl.ProjectEx;
@@ -36,25 +34,28 @@ public class ProjectHandler {
     }
 
     public ProjectParameters getProjectParameters(SBuild build) {
-        ProjectEx project = getProject(build);
-        String apiKey = getApiKey(project);
-        String ddSite = project.getParameterValue(DATADOG_SITE_PARAM);
+        String apiKey = build.getParametersProvider().get(DATADOG_API_KEY_PARAM);
+        if (apiKey == null) {
+            throw new IllegalArgumentException(
+                    format("Could not find required property '%s' for build %s",
+                            DATADOG_API_KEY_PARAM, build.getBuildId()));
+        }
 
+        String ddSite = build.getParametersProvider().get(DATADOG_SITE_PARAM);
         if (ddSite == null) {
             throw new IllegalArgumentException(
-                    format("Could not find required property '%s' for project '%s'. Project parameters: %s",
-                            DATADOG_SITE_PARAM, project.getName(), project.getParameters()));
+                    format("Could not find required property '%s' for build %s",
+                            DATADOG_SITE_PARAM, build.getBuildId()));
         }
 
         return new ProjectParameters(apiKey, ddSite);
     }
 
     public boolean isPluginEnabled(SBuild build) {
-        ProjectEx project = getProject(build);
-        String enabled = project.getParameterValue(DATADOG_ENABLED_PARAM);
+        String enabled = build.getParametersProvider().get(DATADOG_ENABLED_PARAM);
         boolean isPluginEnabled = Boolean.parseBoolean(enabled);
         if (!isPluginEnabled) {
-            LOG.debug(format("Plugin not enabled in project '%s'", project.getFullName()));
+            LOG.debug(format("Plugin not enabled for build %s", build.getBuildId()));
         }
 
         return isPluginEnabled;
@@ -65,19 +66,6 @@ public class ProjectHandler {
         return (ProjectEx) Optional.ofNullable(build.getProjectId())
             .map(projectManager::findProjectById)
             .orElse(projectManager.getRootProject());
-    }
-
-    private String getApiKey(ProjectEx project) {
-        String apiKeyReference = String.format("%%%s%%", DATADOG_API_KEY_PARAM);
-        ValueResolver resolver = project.getValueResolver();
-        ProcessingResult resolved = resolver.resolve(apiKeyReference);
-        if (!resolved.isFullyResolved()) {
-            throw new IllegalArgumentException(
-                    format("Could not find required property '%s' for project '%s'. Project parameters: %s",
-                            DATADOG_API_KEY_PARAM, project.getName(), project.getParameters()));
-        }
-
-        return resolved.getResult();
     }
 
     public static class ProjectParameters {

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -10,13 +10,8 @@ package jetbrains.buildServer.com.datadog.teamcity.plugin;
 import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.parameters.ProcessingResult;
 import jetbrains.buildServer.parameters.ValueResolver;
-import jetbrains.buildServer.serverSide.ProjectManager;
 import jetbrains.buildServer.serverSide.SBuild;
-import jetbrains.buildServer.serverSide.impl.ProjectEx;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.Nonnull;
-import java.util.Optional;
 
 import static java.lang.String.format;
 
@@ -28,12 +23,6 @@ public class ProjectHandler {
     protected static final String DATADOG_API_KEY_PARAM = "datadog.ci.api.key";
     protected static final String DATADOG_SITE_PARAM = "datadog.ci.site";
     protected static final String DATADOG_ENABLED_PARAM = "datadog.ci.enabled";
-
-    private final ProjectManager projectManager;
-
-    public ProjectHandler(ProjectManager projectManager) {
-        this.projectManager = projectManager;
-    }
 
     public ProjectParameters getProjectParameters(SBuild build) {
         String apiKey = getBuildParameter(build, DATADOG_API_KEY_PARAM);
@@ -49,13 +38,6 @@ public class ProjectHandler {
         }
 
         return isPluginEnabled;
-    }
-
-    @Nonnull
-    private ProjectEx getProject(SBuild build) {
-        return (ProjectEx) Optional.ofNullable(build.getProjectId())
-            .map(projectManager::findProjectById)
-            .orElse(projectManager.getRootProject());
     }
 
     private String getBuildParameter(SBuild build, String parameterName) {

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -75,16 +75,14 @@ public class ProjectHandler {
 
     private String getApiKey(SBuild build) {
         // API key is a password parameter and needs ValueResolver to get the unscrambled value
-        // ValueResolver resolves from the project hierarchy, job level overrides are
-        // not possible.
-        ProjectEx project = getProject(build);
+        // Use build's own ValueResolver which is build-aware and should support job-level overrides
         String apiKeyReference = String.format("%%%s%%", DATADOG_API_KEY_PARAM);
-        ValueResolver resolver = project.getValueResolver();
+        ValueResolver resolver = build.getValueResolver();
         ProcessingResult resolved = resolver.resolve(apiKeyReference);
         if (!resolved.isFullyResolved()) {
             throw new IllegalArgumentException(
-                    format("Could not find required property '%s' for project '%s'. Project parameters: %s",
-                            DATADOG_API_KEY_PARAM, project.getName(), project.getParameters()));
+                    format("Could not find required property '%s' for build %s",
+                            DATADOG_API_KEY_PARAM, build.getBuildId()));
         }
 
         return resolved.getResult();

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -8,6 +8,8 @@
 package jetbrains.buildServer.com.datadog.teamcity.plugin;
 
 import com.intellij.openapi.diagnostic.Logger;
+import jetbrains.buildServer.parameters.ProcessingResult;
+import jetbrains.buildServer.parameters.ValueResolver;
 import jetbrains.buildServer.serverSide.ProjectManager;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.impl.ProjectEx;
@@ -34,13 +36,9 @@ public class ProjectHandler {
     }
 
     public ProjectParameters getProjectParameters(SBuild build) {
-        String apiKey = build.getParametersProvider().get(DATADOG_API_KEY_PARAM);
-        if (apiKey == null) {
-            throw new IllegalArgumentException(
-                    format("Could not find required property '%s' for build %s",
-                            DATADOG_API_KEY_PARAM, build.getBuildId()));
-        }
-
+        String apiKey = getApiKey(build);
+        
+        // Site is a regular parameter, use ParametersProvider which includes build + project hierarchy
         String ddSite = build.getParametersProvider().get(DATADOG_SITE_PARAM);
         if (ddSite == null) {
             throw new IllegalArgumentException(
@@ -66,6 +64,22 @@ public class ProjectHandler {
         return (ProjectEx) Optional.ofNullable(build.getProjectId())
             .map(projectManager::findProjectById)
             .orElse(projectManager.getRootProject());
+    }
+
+    private String getApiKey(SBuild build) {
+        // API key is a password parameter and needs ValueResolver to get the unscrambled value
+        // ValueResolver resolves from the project hierarchy, which includes job-level overrides
+        ProjectEx project = getProject(build);
+        String apiKeyReference = String.format("%%%s%%", DATADOG_API_KEY_PARAM);
+        ValueResolver resolver = project.getValueResolver();
+        ProcessingResult resolved = resolver.resolve(apiKeyReference);
+        if (!resolved.isFullyResolved()) {
+            throw new IllegalArgumentException(
+                    format("Could not find required property '%s' for build %s",
+                            DATADOG_API_KEY_PARAM, build.getBuildId()));
+        }
+        
+        return resolved.getResult();
     }
 
     public static class ProjectParameters {

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -13,6 +13,9 @@ import jetbrains.buildServer.parameters.ValueResolver;
 import jetbrains.buildServer.serverSide.SBuild;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static java.lang.String.format;
 
 @Component
@@ -24,6 +27,11 @@ public class ProjectHandler {
     protected static final String DATADOG_SITE_PARAM = "datadog.ci.site";
     protected static final String DATADOG_ENABLED_PARAM = "datadog.ci.enabled";
 
+    // Parameter defaults registry: If entry for parameter is missing a value is required.
+    private static final Map<String, String> PARAMETER_DEFAULTS = new HashMap<String, String>() {{
+        put(DATADOG_ENABLED_PARAM, "false");
+    }};
+
     public ProjectParameters getProjectParameters(SBuild build) {
         String apiKey = getBuildParameter(build, DATADOG_API_KEY_PARAM);
         String ddSite = getBuildParameter(build, DATADOG_SITE_PARAM);
@@ -31,7 +39,7 @@ public class ProjectHandler {
     }
 
     public boolean isPluginEnabled(SBuild build) {
-        String enabled = getBuildParameter(build, DATADOG_ENABLED_PARAM, null);
+        String enabled = getBuildParameter(build, DATADOG_ENABLED_PARAM);
         boolean isPluginEnabled = Boolean.parseBoolean(enabled);
         if (!isPluginEnabled) {
             LOG.debug(format("Plugin not enabled for build %s", build.getBuildId()));
@@ -40,27 +48,28 @@ public class ProjectHandler {
         return isPluginEnabled;
     }
 
+    /**
+     * Get a parameter value from the build. If the parameter is not set:
+     * - Returns the default value if one is registered in PARAMETER_DEFAULTS
+     * - Throws IllegalArgumentException if no default is registered (required parameter)
+     */
     private String getBuildParameter(SBuild build, String parameterName) {
-        // Check parameter exists first
         String value = build.getParametersProvider().get(parameterName);
+        
         if (value == null) {
+            // Check if we have a default value registered
+            if (PARAMETER_DEFAULTS.containsKey(parameterName)) {
+                return PARAMETER_DEFAULTS.get(parameterName);
+            }
+            // No default - this is a required parameter
             throw new IllegalArgumentException(
-                    format("Could not find required property '%s' for build %s",
-                            parameterName, build.getBuildId()));
+                format("Could not find required property '%s' for build %s",
+                        parameterName, build.getBuildId()));
         }
 
         return resolveBuildParameter(build, parameterName);
     }
 
-    private String getBuildParameter(SBuild build, String parameterName, String defaultValue) {
-        // Check if parameter exists
-        String value = build.getParametersProvider().get(parameterName);
-        if (value == null) {
-            return defaultValue;
-        }
-
-        return resolveBuildParameter(build, parameterName);
-    }
 
     private String resolveBuildParameter(SBuild build, String parameterName) {
         // Resolve any %foo% references or passwords in parameters

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -37,20 +37,12 @@ public class ProjectHandler {
 
     public ProjectParameters getProjectParameters(SBuild build) {
         String apiKey = getApiKey(build);
-        
-        // Site is a regular parameter, use ParametersProvider which includes build + project hierarchy
-        String ddSite = build.getParametersProvider().get(DATADOG_SITE_PARAM);
-        if (ddSite == null) {
-            throw new IllegalArgumentException(
-                    format("Could not find required property '%s' for build %s",
-                            DATADOG_SITE_PARAM, build.getBuildId()));
-        }
-
+        String ddSite = getBuildParameter(build, DATADOG_SITE_PARAM);
         return new ProjectParameters(apiKey, ddSite);
     }
 
     public boolean isPluginEnabled(SBuild build) {
-        String enabled = build.getParametersProvider().get(DATADOG_ENABLED_PARAM);
+        String enabled = getBuildParameter(build, DATADOG_ENABLED_PARAM, null);
         boolean isPluginEnabled = Boolean.parseBoolean(enabled);
         if (!isPluginEnabled) {
             LOG.debug(format("Plugin not enabled for build %s", build.getBuildId()));
@@ -64,6 +56,21 @@ public class ProjectHandler {
         return (ProjectEx) Optional.ofNullable(build.getProjectId())
             .map(projectManager::findProjectById)
             .orElse(projectManager.getRootProject());
+    }
+
+    private String getBuildParameter(SBuild build, String parameterName) {
+        String value = build.getParametersProvider().get(parameterName);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    format("Could not find required property '%s' for build %s",
+                            parameterName, build.getBuildId()));
+        }
+        return value;
+    }
+
+    private String getBuildParameter(SBuild build, String parameterName, String defaultValue) {
+        String value = build.getParametersProvider().get(parameterName);
+        return value != null ? value : defaultValue;
     }
 
     private String getApiKey(SBuild build) {

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -83,8 +83,8 @@ public class ProjectHandler {
         ProcessingResult resolved = resolver.resolve(apiKeyReference);
         if (!resolved.isFullyResolved()) {
             throw new IllegalArgumentException(
-                    format("Could not find required property '%s' for build %s",
-                            DATADOG_API_KEY_PARAM, build.getBuildId()));
+                    format("Could not find required property '%s' for project '%s'. Project parameters: %s",
+                            DATADOG_API_KEY_PARAM, project.getName(), project.getParameters()));
         }
 
         return resolved.getResult();

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -36,7 +36,7 @@ public class ProjectHandler {
     }
 
     public ProjectParameters getProjectParameters(SBuild build) {
-        String apiKey = getApiKey(build);
+        String apiKey = getBuildParameter(build, DATADOG_API_KEY_PARAM);
         String ddSite = getBuildParameter(build, DATADOG_SITE_PARAM);
         return new ProjectParameters(apiKey, ddSite);
     }
@@ -59,32 +59,32 @@ public class ProjectHandler {
     }
 
     private String getBuildParameter(SBuild build, String parameterName) {
+        // Check parameter exists first
         String value = build.getParametersProvider().get(parameterName);
         if (value == null) {
             throw new IllegalArgumentException(
                     format("Could not find required property '%s' for build %s",
                             parameterName, build.getBuildId()));
         }
-        return value;
+
+        return resolveBuildParameter(build, parameterName);
     }
 
     private String getBuildParameter(SBuild build, String parameterName, String defaultValue) {
+        // Check if parameter exists
         String value = build.getParametersProvider().get(parameterName);
-        return value != null ? value : defaultValue;
-    }
-
-    private String getApiKey(SBuild build) {
-        // API key is a password parameter and needs ValueResolver to get the unscrambled value
-        // Use build's own ValueResolver which is build-aware and should support job-level overrides
-        String apiKeyReference = String.format("%%%s%%", DATADOG_API_KEY_PARAM);
-        ValueResolver resolver = build.getValueResolver();
-        ProcessingResult resolved = resolver.resolve(apiKeyReference);
-        if (!resolved.isFullyResolved()) {
-            throw new IllegalArgumentException(
-                    format("Could not find required property '%s' for build %s",
-                            DATADOG_API_KEY_PARAM, build.getBuildId()));
+        if (value == null) {
+            return defaultValue;
         }
 
+        return resolveBuildParameter(build, parameterName);
+    }
+
+    private String resolveBuildParameter(SBuild build, String parameterName) {
+        // Use build's ValueResolver to resolve any %references% and handle password parameters
+        String paramReference = String.format("%%%s%%", parameterName);
+        ValueResolver resolver = build.getValueResolver();
+        ProcessingResult resolved = resolver.resolve(paramReference);
         return resolved.getResult();
     }
 

--- a/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
+++ b/datadog-ci-integration-server/src/main/java/jetbrains/buildServer/com/datadog/teamcity/plugin/ProjectHandler.java
@@ -63,11 +63,22 @@ public class ProjectHandler {
     }
 
     private String resolveBuildParameter(SBuild build, String parameterName) {
-        // Use build's ValueResolver to resolve any %references% and handle password parameters
+        // Resolve any %foo% references or passwords in parameters
+        // Try build's ValueResolver first to support job-level overrides
         String paramReference = String.format("%%%s%%", parameterName);
-        ValueResolver resolver = build.getValueResolver();
-        ProcessingResult resolved = resolver.resolve(paramReference);
-        return resolved.getResult();
+        ValueResolver buildResolver = build.getValueResolver();
+        ProcessingResult resolved = buildResolver.resolve(paramReference);
+        String result = resolved.getResult();
+        
+        // If the value is scrambled (password parameter), fall back to project resolver
+        // Build resolver doesn't have access to unscramble passwords
+        if ("*******".equals(result)) {
+            ValueResolver projectResolver = build.getBuildType().getProject().getValueResolver();
+            resolved = projectResolver.resolve(paramReference);
+            result = resolved.getResult();
+        }
+        
+        return result;
     }
 
     public static class ProjectParameters {


### PR DESCRIPTION
What does this PR do?
---------------------

- Allows setting `datadog.ci.` parameters on individual jobs in addition to projects.

### Details

- Modified ProjectHandler to query project parmeter provider.
- Allows individual jobs to override datadog.ci.enabled, datadog.ci.api.key, and datadog.ci.site
- Invoke job-based ValueResolver on all parameters, allowing parameter redirection as well as password parameters.
- Maintains backwards compatibility with existing project-level configurations

This enables more granular control over plugin behavior.

### Limitations

- parameters that stored as type `password`, such as typically `datadog.ci.api.key`, currently have to be defined on the project level

### Review checklist

- [ ] I have added unit tests if applicable
- [x] (Only for critical changes) I have tested that the changes work in a TeamCity server
